### PR TITLE
Fixbug：Modified a SQL statement (that empowering all IP access the mysql) in the Deployment Guide.

### DIFF
--- a/cluster-deploy/README.md
+++ b/cluster-deploy/README.md
@@ -194,7 +194,7 @@ Enter password:(please input the original password)
 After installing mysql, you need to use the following statement on the node where MySQL is installed to empower all IP in the party (replacing IP with actual ip):
 
 ```
-$/data/projects/common/mysql/mysql-8.0.13/bin/mysql -ufate_dev -p –S /data/projects/common/mysql/mysql-8.0.13/mysql.sock
+$/data/projects/common/mysql/mysql-8.0.13/bin/mysql -ufate_dev -p -S /data/projects/common/mysql/mysql-8.0.13/mysql.sock
 Enter password: fate_dev
 >CREATE USER 'fate_dev'@'$ip' IDENTIFIED BY 'fate_dev';
 >GRANT ALL ON *.* TO 'fate_dev'@'$ip';


### PR DESCRIPTION
Fixes Bug:
After installing mysql, when you want to access mysql to empower all IP access, you will get Error by bellow statement, because the character '-' before 'S' should be Half-Angular, not Full-Angular.
--------------
$/data/projects/common/mysql/mysql-8.0.13/bin/mysql -ufate_dev -p –S /data/projects/common/mysql/mysql-8.0.13/mysql.sock
--------------

Changes:
1:  Modified a SQL statement (that empowering all IP access the mysql) in the Deployment Guide.
'–S' --> '-S'
