### PR TITLE
iterative affine cipher added, which no longer discloses the number o…

### DIFF
--- a/federatedml/secureprotol/encrypt.py
+++ b/federatedml/secureprotol/encrypt.py
@@ -25,6 +25,7 @@ from federatedml.secureprotol.fate_paillier import PaillierKeypair
 
 
 # LOGGER = log_utils.getLogger()
+from federatedml.secureprotol.iterative_affine import IterativeAffineCipher
 
 
 class Encrypt(object):
@@ -217,6 +218,26 @@ class AffineEncrypt(SymmetricEncrypt):
 
     def generate_key(self, key_size=1024):
         self.key = AffineCipher.generate_keypair(key_size=key_size)
+
+    def encrypt(self, plaintext):
+        if self.key is not None:
+            return self.key.encrypt(plaintext)
+        else:
+            return None
+
+    def decrypt(self, ciphertext):
+        if self.key is not None:
+            return self.key.decrypt(ciphertext)
+        else:
+            return None
+
+
+class IterativeAffineEncrypt(SymmetricEncrypt):
+    def __init__(self):
+        super(IterativeAffineEncrypt, self).__init__()
+
+    def generate_key(self, key_size=1024, key_round=5):
+        self.key = IterativeAffineCipher.generate_keypair(key_size=key_size, key_round=key_round)
 
     def encrypt(self, plaintext):
         if self.key is not None:

--- a/federatedml/secureprotol/iterative_affine.py
+++ b/federatedml/secureprotol/iterative_affine.py
@@ -1,0 +1,126 @@
+#
+#  Copyright 2019 The FATE Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+import math
+import random
+import numpy as np
+
+from federatedml.secureprotol.affine_encoder import AffineEncoder
+from federatedml.secureprotol.gmpy_math import invert
+
+
+class IterativeAffineCipher(object):
+    """
+    Formulas: The r-th round of encryption method is Enc_r(x) = a_r * x % n_r;
+            The overall encryption scheme is Enc(x) = Enc_n o ... o Enc_1(x)
+    Note: The key round supported is upper bounded by some number dependent of key size.
+    """
+
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def generate_keypair(key_size=1024, key_round=5, encode_precision=2 ** 100):
+        key_size_array = np.linspace(start=int(key_size / 2), stop=key_size, num=key_round)
+        key_size_array = np.floor(key_size_array).astype(np.int64)
+        n_array = [0 for _ in range(key_round)]
+        a_array = [0 for _ in range(key_round)]
+        i = 0
+        for key_size in key_size_array:
+            n = random.SystemRandom().getrandbits(key_size)
+            a_ratio = random.SystemRandom().random()
+            a = 0
+            while True:
+                a_size = int(key_size * a_ratio)
+                if a_size is 0:
+                    continue
+                a = random.SystemRandom().getrandbits(a_size)
+                if math.gcd(n, a) == 1:
+                    break
+            n_array[i] = n
+            a_array[i] = a
+            i = i + 1
+        return IterativeAffineCipherKey(a_array, n_array, encode_precision)
+
+
+class IterativeAffineCipherKey(object):
+    def __init__(self, a_array, n_array, encode_precision=2 ** 100):
+        if len(a_array) != len(n_array):
+            raise ValueError("a_array length must be equal to n_array")
+        self.a_array = a_array
+        self.n_array = n_array
+        self.key_round = len(self.a_array)
+        self.a_inv_array = self.mod_inverse()
+        self.affine_encoder = AffineEncoder(mult=encode_precision)
+
+    def encrypt(self, plaintext):
+        return self.raw_encrypt(self.affine_encoder.encode(plaintext))
+
+    def decrypt(self, ciphertext):
+        if isinstance(ciphertext, int) is True and ciphertext is 0:
+            return 0
+        return self.affine_encoder.decode(self.raw_decrypt(ciphertext))
+
+    def raw_encrypt(self, plaintext):
+        ciphertext = IterativeAffineCiphertext(plaintext)
+        for i in range(self.key_round):
+            ciphertext = self.raw_encrypt_round(ciphertext, i)
+        return ciphertext
+
+    def raw_decrypt(self, ciphertext):
+        plaintext = ciphertext.cipher
+        for i in range(self.key_round):
+            plaintext = self.raw_decrypt_round(plaintext, i)
+        if plaintext / self.n_array[0] > 0.9:
+            return plaintext - self.n_array[0]
+        else:
+            return plaintext
+
+    def raw_encrypt_round(self, plaintext, round_index):
+        return IterativeAffineCiphertext((self.a_array[round_index] * plaintext.cipher) % self.n_array[round_index])
+
+    def raw_decrypt_round(self, ciphertext, round_index):
+        plaintext = (self.a_inv_array[self.key_round - 1 - round_index]
+                     * (ciphertext % self.n_array[self.key_round - 1 - round_index]))\
+                    % self.n_array[self.key_round - 1 - round_index]
+        return plaintext
+
+    def mod_inverse(self):
+        a_array_inv = [0 for _ in self.a_array]
+        for i in range(self.key_round):
+            a_array_inv[i] = invert(self.a_array[i], self.n_array[i])
+        return a_array_inv
+
+
+class IterativeAffineCiphertext(object):
+    def __init__(self, cipher):
+        self.cipher = cipher
+
+    def __add__(self, other):
+        if isinstance(other, IterativeAffineCiphertext):
+            return IterativeAffineCiphertext(self.cipher + other.cipher)
+        elif type(other) is int and other == 0:
+            return self
+        else:
+            raise TypeError("Addition only supports AffineCiphertext and initialization with int zero")
+
+    def __radd__(self, other):
+        return self.__add__(other)
+
+    def __sub__(self, other):
+        return self + (other * -1)
+
+    def __rsub__(self, other):
+        return other + (self * -1)

--- a/federatedml/secureprotol/test/iterative_affine_test.py
+++ b/federatedml/secureprotol/test/iterative_affine_test.py
@@ -1,0 +1,55 @@
+#
+#  Copyright 2019 The FATE Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import numpy as np
+import unittest
+
+from federatedml.secureprotol.iterative_affine import IterativeAffineCipher
+
+
+class TestAffine(unittest.TestCase):
+    def setUp(self):
+        self.key = IterativeAffineCipher.generate_keypair()
+         
+    def tearDown(self):
+        unittest.TestCase.tearDown(self)
+         
+    def test_add(self):
+        x_li = np.ones(100) * np.random.randint(100)
+        y_li = np.ones(100) * np.random.randint(1000)        
+        z_li = np.ones(100) * np.random.rand()
+        t_li = range(100)
+        
+        for i in range(x_li.shape[0]):
+            x = x_li[i]
+            y = y_li[i]
+            z = z_li[i]
+            t = t_li[i]
+            en_x = self.key.encrypt(x)
+            en_y = self.key.encrypt(y)
+            en_z = self.key.encrypt(z)
+            en_t = self.key.encrypt(t)
+            
+            en_res = en_x + en_y + en_z + en_t
+            
+            res = x + y + z + t
+            
+            de_en_res = self.key.decrypt(en_res)
+            self.assertAlmostEqual(de_en_res, res)
+            
+   
+if __name__ == '__main__': 
+    unittest.main()


### PR DESCRIPTION
Fixes  ISSUE#594

Changes:

1. Iterative Affine Cipher added. Compared with Affine Cipher, it does not disclose the number of homomorphic additions.

Signed-off-by: lyyanjiu1jia1 <clarkieliu@tencent.com>