### PR TITLE
add support for IterativeAffine in sbt 

### DIFF
--- a/federatedml/secureprotol/__init__.py
+++ b/federatedml/secureprotol/__init__.py
@@ -14,7 +14,7 @@
 #  limitations under the License.
 #
 
-from federatedml.secureprotol.encrypt import RsaEncrypt, PaillierEncrypt, FakeEncrypt
+from federatedml.secureprotol.encrypt import RsaEncrypt, PaillierEncrypt, FakeEncrypt, AffineEncrypt
 from federatedml.secureprotol.encrypt_mode import EncryptModeCalculator
 
-__all__ = ['RsaEncrypt', 'PaillierEncrypt', 'FakeEncrypt', 'EncryptModeCalculator']
+__all__ = ['RsaEncrypt', 'PaillierEncrypt', 'FakeEncrypt', 'EncryptModeCalculator', 'AffineEncrypt']

--- a/federatedml/secureprotol/__init__.py
+++ b/federatedml/secureprotol/__init__.py
@@ -14,7 +14,7 @@
 #  limitations under the License.
 #
 
-from federatedml.secureprotol.encrypt import RsaEncrypt, PaillierEncrypt, FakeEncrypt, AffineEncrypt
+from federatedml.secureprotol.encrypt import RsaEncrypt, PaillierEncrypt, FakeEncrypt, AffineEncrypt, IterativeAffineEncrypt
 from federatedml.secureprotol.encrypt_mode import EncryptModeCalculator
 
-__all__ = ['RsaEncrypt', 'PaillierEncrypt', 'FakeEncrypt', 'EncryptModeCalculator', 'AffineEncrypt']
+__all__ = ['RsaEncrypt', 'PaillierEncrypt', 'FakeEncrypt', 'EncryptModeCalculator', 'AffineEncrypt', 'IterativeAffineEncrypt']

--- a/federatedml/tree/hetero_secureboosting_tree_guest.py
+++ b/federatedml/tree/hetero_secureboosting_tree_guest.py
@@ -39,6 +39,7 @@ from federatedml.util.transfer_variable.hetero_secure_boost_transfer_variable im
 from federatedml.util import consts
 from federatedml.secureprotol import PaillierEncrypt
 from federatedml.secureprotol import AffineEncrypt
+from federatedml.secureprotol import IterativeAffineEncrypt
 from federatedml.secureprotol.encrypt_mode import EncryptModeCalculator
 from federatedml.loss import SigmoidBinaryCrossEntropyLoss
 from federatedml.loss import SoftmaxCrossEntropyLoss
@@ -176,11 +177,14 @@ class HeteroSecureBoostingTreeGuest(BoostingTree):
 
     def generate_encrypter(self):
         LOGGER.info("generate encrypter")
-        if self.encrypt_param.method == consts.PAILLIER:
+        if self.encrypt_param.method.lower() == consts.PAILLIER.lower():
             self.encrypter = PaillierEncrypt()
             self.encrypter.generate_key(self.encrypt_param.key_length)
-        elif self.encrypt_param.method == consts.AFFINE:
+        elif self.encrypt_param.method.lower() == consts.AFFINE.lower():
             self.encrypter = AffineEncrypt()
+            self.encrypter.generate_key(self.encrypt_param.key_length)
+        elif self.encrypt_param.method.lower() == consts.ITERATIVEAFFINE.lower():
+            self.encrypter = IterativeAffineEncrypt()
             self.encrypter.generate_key(self.encrypt_param.key_length)
         else:
             raise NotImplementedError("encrypt method not supported yes!!!")

--- a/federatedml/tree/hetero_secureboosting_tree_guest.py
+++ b/federatedml/tree/hetero_secureboosting_tree_guest.py
@@ -38,7 +38,6 @@ from federatedml.util.transfer_variable.hetero_secure_boost_transfer_variable im
     HeteroSecureBoostingTreeTransferVariable
 from federatedml.util import consts
 from federatedml.secureprotol import PaillierEncrypt
-from federatedml.secureprotol import AffineEncrypt
 from federatedml.secureprotol import IterativeAffineEncrypt
 from federatedml.secureprotol.encrypt_mode import EncryptModeCalculator
 from federatedml.loss import SigmoidBinaryCrossEntropyLoss
@@ -179,9 +178,6 @@ class HeteroSecureBoostingTreeGuest(BoostingTree):
         LOGGER.info("generate encrypter")
         if self.encrypt_param.method.lower() == consts.PAILLIER.lower():
             self.encrypter = PaillierEncrypt()
-            self.encrypter.generate_key(self.encrypt_param.key_length)
-        elif self.encrypt_param.method.lower() == consts.AFFINE.lower():
-            self.encrypter = AffineEncrypt()
             self.encrypter.generate_key(self.encrypt_param.key_length)
         elif self.encrypt_param.method.lower() == consts.ITERATIVEAFFINE.lower():
             self.encrypter = IterativeAffineEncrypt()

--- a/federatedml/tree/hetero_secureboosting_tree_guest.py
+++ b/federatedml/tree/hetero_secureboosting_tree_guest.py
@@ -38,6 +38,7 @@ from federatedml.util.transfer_variable.hetero_secure_boost_transfer_variable im
     HeteroSecureBoostingTreeTransferVariable
 from federatedml.util import consts
 from federatedml.secureprotol import PaillierEncrypt
+from federatedml.secureprotol import AffineEncrypt
 from federatedml.secureprotol.encrypt_mode import EncryptModeCalculator
 from federatedml.loss import SigmoidBinaryCrossEntropyLoss
 from federatedml.loss import SoftmaxCrossEntropyLoss
@@ -177,6 +178,9 @@ class HeteroSecureBoostingTreeGuest(BoostingTree):
         LOGGER.info("generate encrypter")
         if self.encrypt_param.method == consts.PAILLIER:
             self.encrypter = PaillierEncrypt()
+            self.encrypter.generate_key(self.encrypt_param.key_length)
+        elif self.encrypt_param.method == consts.AFFINE:
+            self.encrypter = AffineEncrypt()
             self.encrypter.generate_key(self.encrypt_param.key_length)
         else:
             raise NotImplementedError("encrypt method not supported yes!!!")

--- a/federatedml/util/consts.py
+++ b/federatedml/util/consts.py
@@ -24,6 +24,7 @@ CLASSIFICATION = "classification"
 REGRESSION = 'regression'
 PAILLIER = 'Paillier'
 AFFINE = 'Affine'
+ITERATIVEAFFINE = 'IterativeAffine'
 L1_PENALTY = 'L1'
 L2_PENALTY = 'L2'
 

--- a/federatedml/util/consts.py
+++ b/federatedml/util/consts.py
@@ -23,6 +23,7 @@ MULTY = 'multi'
 CLASSIFICATION = "classification"
 REGRESSION = 'regression'
 PAILLIER = 'Paillier'
+AFFINE = 'Affine'
 L1_PENALTY = 'L1'
 L2_PENALTY = 'L2'
 


### PR DESCRIPTION
Changes:

1. add AFFINE/ITERATIVEAFFINE CONST in consts.py
2. add IterativeAffine support in tree/hetero_secureboosting_tree_guest.py
3. add Affine/IterativeAffine in secureprotol/init.py

Signed-off-by: sookieqinsookieqin@tencent.com


