### PR TITLE
Bug: Module name ended with letter p or y, will raise ModuleNotFoundError

### DIFF
--- a/fate_flow/driver/task_executor.py
+++ b/fate_flow/driver/task_executor.py
@@ -93,7 +93,7 @@ class TaskExecutor(object):
             task.f_run_ip = get_lan_ip()
             task.f_run_pid = os.getpid()
             run_class_paths = parameters.get('CodePath').split('/')
-            run_class_package = '.'.join(run_class_paths[:-2]) + '.' + run_class_paths[-2].rstrip('.py')
+            run_class_package = '.'.join(run_class_paths[:-2]) + '.' + run_class_paths[-2].replace('.py','')
             run_class_name = run_class_paths[-1]
             task_run_args = TaskExecutor.get_task_run_args(job_id=job_id, role=role, party_id=party_id,
                                                            job_parameters=job_parameters, job_args=job_args,


### PR DESCRIPTION
描述：算法模块名结尾不能是p/y结尾，否则调用时会出现ModuleNotFoundError
Description: Customized module name ended with letter p or y, will raise ModuleNotFoundError when used 

原因：
在FATE1.0 /fate/python/fate_flow/driver/task_executor.py 模块96行有如下语句用于拼接模块路径
run_class_package = '.'.join(run_class_paths[:-2]) + '.' + run_class_paths[-2].rstrip('.py')
当模块名末尾含有p/y的时候，会被rstrip函数递归去掉出现在末尾的给定字符，导致无法找到模块
Cause:
Following code is used to concatenate module path in /fate/python/fate_flow/driver/task_executor.py line 96:
run_class_package = '.'.join(run_class_paths[:-2]) + '.' + run_class_paths[-2].rstrip('.py')
Letter p/y in the end of module name will be replaced recursively, leading to a  ModuleNotFoundError

举例：
例如当模块名叫做testonly.py, 会报ModuleNotFoundError: No module named 'federatedml.feature.testonl'错误
Example:
A module called testonly.py will raise ModuleNotFoundError: No module named 'federatedml.feature.testonl'

改进方法：
将rstrip方法改成replace方法即可，及将上述语句改成
run_class_package = '.'.join(run_class_paths[:-2]) + '.' + run_class_paths[-2].replace('.py','')
合符规范的模块名只会在最后出现'.py'这三个字符，不会误伤
Solution:
just replace "rstrip" method with "replace" method, so code cited above will be revised as
run_class_package = '.'.join(run_class_paths[:-2]) + '.' + run_class_paths[-2].replace('.py','')
the phrase '.py' only appear at the end of module path, thus no side-effect will be caused