### PR TITLE
allow to download from other pip repo

### DIFF
--- a/standalone-deploy/docker/python/Dockerfile
+++ b/standalone-deploy/docker/python/Dockerfile
@@ -48,7 +48,7 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 RUN apt-get update && apt-get install libgmp3-dev -y && apt-get install -y libmpfr-dev libmpfr-doc libmpfr6 && apt-get install libmpc-dev -y
 
 #RUN pip install -r requirements.txt -f ./pip-dependedocker ncies --no-index
-RUN pip install -i https://pypi.tuna.tsinghua.edu.cn/simple -r requirements.txt
+RUN pip install -r requirements.txt
 
 ENV PYTHONPATH /fate
 


### PR DESCRIPTION
Fixes  ISSUE#xxx

Changes:

1. when running build-standalone outside China has timeout error because pypi.tuna.tsinghua.edu.cn is not accessible/blocked. By removing this, the issue can be resolved.


