### PR TITLE
Develop 1.3 sparse poisson

### DIFF
--- a/examples/federatedml-1.x-examples/hetero_linear_regression/README.md
+++ b/examples/federatedml-1.x-examples/hetero_linear_regression/README.md
@@ -30,6 +30,12 @@ This section introduces the dsl and conf for usage of different tasks.
 
     conf: test_hetero_linr_multi_host_cv_job_conf.json
 
+6. Train Task with Sparse Data:
+    
+     dsl: test_hetero_linr_train_job_dsl.json
+
+    runtime_config : test_hetero_linr_train_sparse_job_conf.json
+
 
 Users can use following commands to run the task.
 

--- a/examples/federatedml-1.x-examples/hetero_linear_regression/test_hetero_linr_train_sparse_job_conf.json
+++ b/examples/federatedml-1.x-examples/hetero_linear_regression/test_hetero_linr_train_sparse_job_conf.json
@@ -55,7 +55,7 @@
       },
       "dataio_0": {
         "with_label": [false],
-        "output_format": ["dense"],
+        "output_format": ["sparse"],
         "outlier_replace": [false]
       },
       "evaluation_0": {

--- a/examples/federatedml-1.x-examples/hetero_poisson_regression/README.md
+++ b/examples/federatedml-1.x-examples/hetero_poisson_regression/README.md
@@ -12,8 +12,15 @@ This section introduces the dsl and conf for usage of different tasks.
 2. Predict Task:
 
     runtime_config: test_predict_conf.json
+    
+3. Train Task with Sparse Data:
+    
+    dsl: test_hetero_poisson_train_job_dsl.json
 
-3. Cross Validation Task:
+    runtime_config : test_hetero_poisson_train_sparse_job_conf.json
+    (with exposure variable column name specified)
+
+4. Cross Validation Task:
 
     dsl: test_hetero_poisson_cv_job_dsl.json
 

--- a/examples/federatedml-1.x-examples/hetero_poisson_regression/hetero_poisson_testsuite.json
+++ b/examples/federatedml-1.x-examples/hetero_poisson_regression/hetero_poisson_testsuite.json
@@ -26,6 +26,10 @@
       "conf": "test_predict_conf.json",
       "deps": "poisson"
     },
+    "poisson-sparse": {
+      "conf": "test_hetero_poisson_train_sparse_job_conf.json",
+      "dsl": "test_hetero_poisson_train_job_dsl.json"
+    },
     "poisson-cv": {
       "conf": "test_hetero_poisson_cv_job_conf.json",
       "dsl": "test_hetero_poisson_cv_job_dsl.json"

--- a/examples/federatedml-1.x-examples/hetero_poisson_regression/test_hetero_poisson_train_sparse_job_conf.json
+++ b/examples/federatedml-1.x-examples/hetero_poisson_regression/test_hetero_poisson_train_sparse_job_conf.json
@@ -1,0 +1,187 @@
+{
+  "initiator": {
+    "role": "guest",
+    "party_id": 10000
+  },
+  "job_parameters": {
+    "work_mode": 0
+  },
+  "role": {
+    "guest": [
+      10000
+    ],
+    "host": [
+      10000
+    ],
+    "arbiter": [
+      10000
+    ]
+  },
+  "role_parameters": {
+    "guest": {
+      "args": {
+        "data": {
+          "train_data": [
+            {
+              "name": "dvisits_b",
+              "namespace": "dvisits"
+            }
+          ]
+        }
+      },
+      "dataio_0": {
+        "with_label": [true],
+        "label_name": ["doctorco"],
+        "label_type": ["float"],
+        "output_format": ["sparse"],
+        "missing_fill": [true],
+        "outlier_replace": [true]
+      },
+      "feature_scale_0": {
+        "method": ["standard_scale"],
+        "need_run": [false]
+      },
+      "hetero_feature_binning_0": {
+        "method": ["quantile"],
+        "compress_thres": [10000],
+        "head_size": [10000],
+        "error": [0.001],
+        "bin_num": [10],
+        "cols": [-1],
+        "adjustment_factor": [0.5],
+        "local_only": [false],
+        "transform_param": {
+          "transform_cols": [-1],
+          "transform_type": ["bin_num"]
+        }
+      },
+      "hetero_feature_selection_0": {
+        "select_cols": [-1],
+        "filter_methods": [[
+          "unique_value",
+          "iv_value_thres",
+          "coefficient_of_variation_value_thres",
+          "iv_percentile",
+          "outlier_cols"
+        ]],
+        "local_only": [false],
+        "unique_param": {
+          "eps": [1e-6]
+        },
+        "iv_value_param": {
+          "value_threshold": [1.0]
+        },
+        "iv_percentile_param": {
+          "percentile_threshold": [0.9]
+        },
+        "variance_coe_param": {
+          "value_threshold": [0.3]
+        },
+        "outlier_param": {
+          "percentile": [0.95],
+          "upper_threshold": [10]
+        }
+      },
+      "evaluation_0": {
+        "eval_type": ["regression"],
+        "pos_label": [1]
+      }
+    },
+    "host": {
+      "args": {
+        "data": {
+          "train_data": [
+            {
+              "name": "dvisits_a",
+              "namespace": "dvisits"
+            }
+          ]
+        }
+      },
+      "dataio_0": {
+        "with_label": [false],
+        "output_format": ["sparse"],
+        "outlier_replace": [true]
+      },
+      "feature_scale_0": {
+        "method": ["standard_scale"],
+        "need_run": [false]
+      },
+      "hetero_feature_binning_0": {
+        "method": ["quantile"],
+        "compress_thres": [10000],
+        "head_size": [10000],
+        "error": [0.001],
+        "bin_num": [10],
+        "cols": [-1],
+        "adjustment_factor": [0.5],
+        "local_only": [false],
+        "transform_param": {
+          "transform_cols": [-1],
+          "transform_type": ["bin_num"]
+        }
+      },
+      "hetero_feature_selection_0": {
+        "select_cols": [-1],
+        "filter_methods": [[
+          "unique_value",
+          "iv_value_thres",
+          "coefficient_of_variation_value_thres",
+          "iv_percentile",
+          "outlier_cols"
+        ]],
+        "local_only": [false],
+        "unique_param": {
+          "eps": [1e-6]
+        },
+        "iv_value_param": {
+          "value_threshold": [1.0]
+        },
+        "iv_percentile_param": {
+          "percentile_threshold": [0.9]
+        },
+        "variance_coe_param": {
+          "value_threshold": [0.3]
+        },
+        "outlier_param": {
+          "percentile": [0.95],
+          "upper_threshold": [10]
+        }
+      },
+      "evaluation_0": {
+        "need_run": [false]
+      }
+    }
+  },
+  "algorithm_parameters": {
+    "hetero_poisson_0": {
+      "penalty": "L2",
+      "optimizer": "rmsprop",
+      "tol": 1e-3,
+      "alpha": 1e2,
+      "max_iter": 20,
+      "early_stop": "weight_diff",
+      "decay": 0.0,
+      "decay_sqrt": false,
+      "batch_size": -1,
+      "learning_rate": 0.01,
+      "exposure_colname": "exposure",
+      "init_param": {
+        "init_method": "zeros",
+        "init_const": 0
+      },
+      "encrypted_mode_calculator_param": {
+        "mode": "fast"
+      },
+      "cv_param": {
+        "n_splits": 5,
+        "shuffle": false,
+        "random_seed": 103,
+        "need_cv": false,
+        "evaluate_param": {
+          "eval_type": "regression"
+        }
+      }
+    }
+  }
+}

--- a/federatedml/linear_model/linear_regression/hetero_linear_regression/hetero_linr_host.py
+++ b/federatedml/linear_model/linear_regression/hetero_linear_regression/hetero_linr_host.py
@@ -112,6 +112,7 @@ class HeteroLinRHost(HeteroLinRBase):
         ----------
         data_instances:DTable of Instance, input data
         """
+        self.transfer_variable.host_partial_prediction.disable_auto_clean()
         LOGGER.info("Start predict ...")
 
         data_features = self.transform(data_instances)

--- a/federatedml/linear_model/poisson_regression/hetero_poisson_regression/hetero_poisson_host.py
+++ b/federatedml/linear_model/poisson_regression/hetero_poisson_regression/hetero_poisson_host.py
@@ -73,7 +73,7 @@ class HeteroPoissonHost(HeteroPoissonBase):
             LOGGER.info("iter:" + str(self.n_iter_))
 
             batch_data_generator = self.batch_generator.generate_batch_data()
-            self.optimizer.set_iters(self.n_iter_ + 1)
+            self.optimizer.set_iters(self.n_iter_)
 
             batch_index = 0
             for batch_data in batch_data_generator:

--- a/federatedml/linear_model/poisson_regression/hetero_poisson_regression/hetero_poisson_host.py
+++ b/federatedml/linear_model/poisson_regression/hetero_poisson_regression/hetero_poisson_host.py
@@ -114,6 +114,7 @@ class HeteroPoissonHost(HeteroPoissonBase):
         ----------
         data_instances:DTable of Instance, input data
         """
+        self.transfer_variable.host_partial_prediction.disable_auto_clean()
         LOGGER.info("Start predict ...")
         data_features = self.transform(data_instances)
         pred_host = self.compute_mu(data_features, self.model_weights.coef_, self.model_weights.intercept_)


### PR DESCRIPTION
Fixes  ISSUE #1047

Changes:

1. Fix auto clean issue in LinR & Poisson Host by disabling auto clean for partial prediction transfer variable. 

2. Add example configuration file with sparse-data input for Hetero Poisson Regression.

3. Edit example doc to include sparse examples. 