### PR TITLE
Feature 1.4 check none federation

### DIFF
--- a/arch/api/impl/based_1x/federation_cluster.py
+++ b/arch/api/impl/based_1x/federation_cluster.py
@@ -166,6 +166,9 @@ class FederationRuntime(Federation):
         _fill_cache(self.all_parties, self.local_party, self._session_id)
 
     def remote(self, obj, name: str, tag: str, parties: Union[Party, list]) -> Rubbish:
+        if obj is None:
+            raise EnvironmentError(f"federation try to remote None to {parties} with name {name}, tag {tag}")
+
         if isinstance(parties, Party):
             parties = [parties]
 
@@ -269,6 +272,8 @@ class FederationRuntime(Federation):
         rubbish = None
         for p, v in self.async_get(name, tag, parties):
             if p is not None:
+                if v is None:
+                    raise EnvironmentError(f"federation get None from {p} with name {name}, tag {tag}")
                 rtn[p] = v
             else:
                 rubbish = v

--- a/arch/api/impl/based_1x/federation_standalone.py
+++ b/arch/api/impl/based_1x/federation_standalone.py
@@ -57,6 +57,9 @@ class FederationRuntime(Federation):
         self._loop = asyncio.get_event_loop()
 
     def remote(self, obj, name: str, tag: str, parties: Union[Party, list]) -> Rubbish:
+        if obj is None:
+            raise EnvironmentError(f"federation try to remote None to {parties} with name {name}, tag {tag}")
+
         if isinstance(parties, Party):
             parties = [parties]
 
@@ -121,6 +124,8 @@ class FederationRuntime(Federation):
 
             else:  # todo: should standalone mode split large object?
                 obj = _object_table.get(r)
+                if obj is None:
+                    raise EnvironmentError(f"federation get None from {parties} with name {name}, tag {tag}")
                 rtn.append(obj)
                 rubbish.add_obj(_object_table, r)
                 rubbish.add_obj(_status_table, r)

--- a/arch/api/impl/based_2x/federation.py
+++ b/arch/api/impl/based_2x/federation.py
@@ -98,6 +98,8 @@ class FederationRuntime(Federation):
         return rtn, rubbish
 
     def remote(self, obj, name, tag, parties):
+        if obj is None:
+            raise EnvironmentError(f"federation try to remote None to {parties} with name {name}, tag {tag}")
 
         rs = self.rsc.load(name=name, tag=tag)
         rubbish = Rubbish(name=name, tag=tag)

--- a/arch/api/session.py
+++ b/arch/api/session.py
@@ -94,8 +94,11 @@ def table(name, namespace=None, partition=1, persistent=True, create_if_missing=
 
 
 @log_elapsed
-def parallelize(data: Iterable, include_key=False, name=None, partition=1, namespace=None, persistent=False,
+def parallelize(data: Iterable, include_key=False, name=None, partition=None, namespace=None, persistent=False,
                 create_if_missing=True, error_if_exist=False, chunk_size=100000, in_place_computing=False) -> Table:
+
+    if partition is None:
+        raise ValueError("partition should be manual set in this version")
     return RuntimeInstance.SESSION.parallelize(data=data, include_key=include_key, name=name, partition=partition,
                                                namespace=namespace,
                                                persistent=persistent,

--- a/federatedml/nn/homo_nn/enter_point.py
+++ b/federatedml/nn/homo_nn/enter_point.py
@@ -221,11 +221,11 @@ class HomoNNClient(HomoNNBase):
 
         if num_output_units[0] == 1:
             kv = [(x[0], (0 if x[1][0] <= threshold else 1, x[1][0].item())) for x in zip(data.get_keys(), predict)]
-            pred_tbl = session.parallelize(kv, include_key=True)
+            pred_tbl = session.parallelize(kv, include_key=True, partition=data_inst.get_partitions())
             return data_inst.join(pred_tbl, lambda d, pred: [d.label, pred[0], pred[1], {"label": pred[0]}])
         else:
             kv = [(x[0], (x[1].argmax(), [float(e) for e in x[1]])) for x in zip(data.get_keys(), predict)]
-            pred_tbl = session.parallelize(kv, include_key=True)
+            pred_tbl = session.parallelize(kv, include_key=True, partition=data_inst.get_partitions())
             return data_inst.join(pred_tbl,
                                   lambda d, pred: [d.label, pred[0].item(),
                                                    pred[1][pred[0]] / (sum(pred[1])),


### PR DESCRIPTION
Fixes  ISSUE #xxx

Changes:

1. add check whether remote or get `None` obj

2.add check whether partition is provided when calling parallelize

3.fix homo nn parallelize bug


