### PR TITLE
modify num_tree in early stop examples

### DIFF
--- a/examples/federatedml-1.x-examples/hetero_secureboost/test_secureboost_train_with_early_stopping_conf.json
+++ b/examples/federatedml-1.x-examples/hetero_secureboost/test_secureboost_train_with_early_stopping_conf.json
@@ -42,7 +42,7 @@
         "secureboost_0": {
             "task_type": "regression",
             "learning_rate": 0.5,
-            "num_trees": 100,
+            "num_trees": 5,
             "subsample_feature_rate": 1,
             "n_iter_no_change": false,
             "tol": 0.0001,


### PR DESCRIPTION
Signed-off-by: mgqa34 <mgq3374541@163.com>

Fixes  ISSUE #xxx

Changes:

1. change num_trees from 100 in 5 in hetero_secureboost early stop examples

2.

3.


