### PR TITLE
never copy or deepcopy to create new variable instance

### DIFF
--- a/federatedml/transfer_variable/base_transfer_variable.py
+++ b/federatedml/transfer_variable/base_transfer_variable.py
@@ -69,6 +69,14 @@ class Variable(object):
         self._auto_clean = True
         self._preserve_num = 2
 
+    # copy never create a new instance
+    def __copy__(self):
+        return self
+
+    # deepcopy never create a new instance
+    def __deepcopy__(self, memo):
+        return self
+
     def set_preserve_num(self, n):
         self._preserve_num = n
         return self


### PR DESCRIPTION
Signed-off-by: weiwee <wbwmat@gmail.com>
Changes:

1. deepcopy may create a new cleaner in the variable, overwriting the magic functions __deepcopy__ and __copy__ to avoid this from happening



