### PR TITLE
fix readthedocs url

### DIFF
--- a/standalone-deploy/README.rst
+++ b/standalone-deploy/README.rst
@@ -5,11 +5,11 @@ The stand-alone version provides 2 deployment methods, which can be
 selected according to your actual situation:
 
 -  Install FATE using Docker `Chinese
-   guide <./doc/Fate-standalone_deployment_guide_zh.md>`__
+   guide <https://github.com/FederatedAI/FATE/blob/master/standalone-deploy/doc/Fate-standalone_deployment_guide_zh.md>`__
    *(Recommended)*
 
 -  Install FATE in Host `Chinese
-   guide <./doc/Fate-standalone_deployment_guide_zh.md>`__
+   guide <https://github.com/FederatedAI/FATE/blob/master/standalone-deploy/doc/Fate-standalone_deployment_guide_zh.md>`__
 
 1) Install FATE using Docker\ *(Recommended)*
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Fixes  bad URL in readthedocs,

when linking another website URL, you may need to  use the absolute path rather than relative path in your docs

Changes:

1. fix readthedocs bad URL, at https://fate.readthedocs.io/en/latest/standalone-deploy/README.html [Chinse guide]

2.

3.


