### PR TITLE
Update rabbit manager

### DIFF
--- a/doc/dsl_conf_v2_setting_guide.rst
+++ b/doc/dsl_conf_v2_setting_guide.rst
@@ -303,6 +303,11 @@ Besides the dsl conf, user also need to prepare a submit runtime conf to set the
      - num-executors, executor-cores
      - parameter for SPARK computing engine
 
+   * - rabbitmq_run
+     -
+     - queue, exchange etc.
+     - parameters for creation of queue, exchange in rabbitmq
+
    * - task_parallelism
      - 2
      - positive int

--- a/doc/job_config_guide_zh.md
+++ b/doc/job_config_guide_zh.md
@@ -87,6 +87,9 @@ Job Runtime Conf用于设置各个参与方的信息,任务的参数及各个组
     "rabbitmq_run": {
         "queue": {
             "durable": true
+        },
+        "connection": {
+            "heartbeat": 10000
         }
     }
 }

--- a/doc/job_config_guide_zh.md
+++ b/doc/job_config_guide_zh.md
@@ -44,6 +44,7 @@ Job Runtime Conf用于设置各个参与方的信息,任务的参数及各个组
   | timeout | 604800 | 正整数 | 任务超时时间,单位秒 |
   | eggroll_run | 无| processors_per_node| eggroll计算引擎相关配置参数|
   | spark_run | 无| num-executors、executor-cores |spark计算引擎相关配置参数 |
+  | rabbitmq_run | 无| queue、exchange| rabbitmq 创建queue、exchange的相关配置参数|
   | task_parallelism | 2 | 正整数 | task并行度 |
   | task_nodes | 1 | 正整数 | 使用的计算节点数 |
   | task_cores_per_node | 2 | 正整数 | 每个节点使用的CPU核数 |
@@ -82,6 +83,11 @@ Job Runtime Conf用于设置各个参与方的信息,任务的参数及各个组
     "spark_run": {
         "num-executors": 1,
         "executor-cores": 2
+    },
+    "rabbitmq_run": {
+        "queue": {
+            "durable": true
+        }
     }
 }
 ```

--- a/python/fate_arch/federation/rabbitmq/_federation.py
+++ b/python/fate_arch/federation/rabbitmq/_federation.py
@@ -124,14 +124,9 @@ class Federation(FederationABC):
 
         self._queue_map: typing.MutableMapping[Party, _QueueNames] = {}
         self._channels_map = {}
-<<<<<<< HEAD
-     
-    def get(self, name: str, tag: str, parties: typing.List[Party], gc: GarbageCollectionABC) -> typing.List:
-=======
         self._max_message_size = max_message_size
 
-    def get(self, name, tag, parties: typing.List[Party], gc: GarbageCollectionABC) -> typing.List:
->>>>>>> Finish the Update of RabbitMQ manager
+    def get(self, name: str, tag: str, parties: typing.List[Party], gc: GarbageCollectionABC) -> typing.List:
         log_str = f"rabbitmq.get(name={name}, tag={tag}, parties={parties})"
         LOGGER.debug(f"[{log_str}]start to get")
 
@@ -224,15 +219,9 @@ class Federation(FederationABC):
             self._rabbit_manager.federate_queue(upstream_host=upstream_uri, vhost=names.vhost,
                                                 send_queue_name=names.send, receive_queue_name=names.receive)
 
-<<<<<<< HEAD
             self._queue_map[name_party] = names
-            LOGGER.debug(f"[rabbitmq.get_or_create_queue]queue for name: {name}, party:{party} created, names: {names}")
-=======
             # TODO: check federated queue status
-
-            self._queue_map[party] = names
-            LOGGER.debug(f"[rabbitmq.get_or_create_queue]queue for party:{party} created, names: {names}")
->>>>>>> Finish the Update of RabbitMQ manager
+            LOGGER.debug(f"[rabbitmq.get_or_create_queue]queue for name: {name}, party:{party} created, names: {names}")
 
         names = self._queue_map[name_party]
         LOGGER.debug(f"[rabbitmq.get_or_create_queue]get queue: names: {names}")
@@ -250,13 +239,8 @@ class Federation(FederationABC):
             name, role, party_id = name_party.split("^")
             info = self._channels_map.get(name_party)
             if info is None:
-<<<<<<< HEAD
-                info = _get_channel(self._mq, names, party_id=party_id, role=role)
+                info = _get_channel(self._mq, names, party_id=party_id, role=role, connection_conf=self._rabbit_manager.runtime_config.get('connection', {}))
                 self._channels_map[name_party] = info
-=======
-                info = _get_channel(self._mq, names, party_id=party.party_id, role=party.role, connection_conf=self._rabbit_manager.runtime_config.get('connection', {}))
-                self._channels_map[party] = info
->>>>>>> Finish the Update of RabbitMQ manager
             channel_infos.append(info)
         return channel_infos
 
@@ -264,21 +248,7 @@ class Federation(FederationABC):
 def _get_channel(mq, names: _QueueNames, party_id, role, connection_conf: dict):
     return MQChannel(host=mq.host, port=mq.port, user=mq.union_name, password=mq.policy_id,
                      vhost=names.vhost, send_queue_name=names.send, receive_queue_name=names.receive, 
-<<<<<<< HEAD
-                     party_id=party_id, role=role)
-
-# can't pickle _thread.lock objects
-def _get_channels(mq_names, mq):
-    channel_infos = []
-    for name_party, names in mq_names.items():
-        name, role, party_id = name_party.split("^")
-        info = _get_channel(mq, names, party_id=party_id, role=role)
-        channel_infos.append(info)
-    return channel_infos
-
-=======
                      party_id=party_id, role=role, extra_args=connection_conf)
->>>>>>> Finish the Update of RabbitMQ manager
 
 def _send_kv(name, tag, data, channel_infos, total_size, partitions):
     headers = {"total_size": total_size, "partitions": partitions}
@@ -311,16 +281,11 @@ MESSAGE_MAX_SIZE = 50000
 # can't pickle _thread.lock objects
 def _get_channels(mq_names, mq, connection_conf: dict):
     channel_infos = []
-    for party, names in mq_names.items():
-        info = _get_channel(mq, names, party_id=party.party_id, role=party.role, connection_conf=connection_conf)
+    for name_party, names in mq_names.items():
+        name, role, party_id = name_party.split("^")
+        info = _get_channel(mq, names, party_id=party_id, role=role, connection_conf=connection_conf)
         channel_infos.append(info)
     return channel_infos
-
-
-<<<<<<< HEAD
-=======
-
->>>>>>> Finish the Update of RabbitMQ manager
 
 def _partition_snd(kvs, name, tag, total_size, partitions, mq_names, mq, maximun_message_size, connection_conf: dict):
     LOGGER.debug(

--- a/python/fate_arch/federation/rabbitmq/_federation.py
+++ b/python/fate_arch/federation/rabbitmq/_federation.py
@@ -14,7 +14,10 @@
 #  limitations under the License.
 #
 
+import io
 import json
+import sys
+import time
 import typing
 from pickle import dumps as p_dumps, loads as p_loads
 
@@ -31,7 +34,31 @@ from fate_arch.federation.rabbitmq._mq_channel import MQChannel
 from fate_arch.federation.rabbitmq._rabbit_manager import RabbitManager
 
 LOGGER = getLogger()
+# default message max size in bytes = 128MB
+DEFAULT_MESSAGE_MAX_SIZE = 134217728
 
+# Datastream is a wraper of StringIO, it receives kv pairs and dump it to json string
+class Datastream(object):
+    def __init__(self):
+        self._string = io.StringIO()
+        self._string.write('[')
+
+    def get_size(self):
+        return sys.getsizeof(self._string.getvalue())
+
+    def get_data(self):
+        self._string.write(']')
+        return self._string.getvalue()
+
+    def append(self, kv: dict):
+        # add ',' if not the first element
+        if self._string.getvalue() != '[':
+            self._string.write(',')
+        json.dump(kv, self._string)
+
+    def clear(self):
+        self._string.close()
+        self.__init__()
 
 class MQ(object):
     def __init__(self, host, port, union_name, policy_id, route_table):
@@ -77,6 +104,8 @@ class Federation(FederationABC):
         policy_id = federation_info.get("policy_id")
 
         rabbitmq_run = runtime_conf.get('job_parameters', {}).get('rabbitmq_run', {})
+        max_message_size = rabbitmq_run.get('max_message_size', DEFAULT_MESSAGE_MAX_SIZE)
+        LOGGER.debug(f'set max message size to {max_message_size} Bytes')
 
         rabbit_manager = RabbitManager(base_user, base_password, f"{host}:{mng_port}", rabbitmq_run)
         rabbit_manager.create_user(union_name, policy_id)
@@ -85,9 +114,9 @@ class Federation(FederationABC):
             route_table_path = "conf/rabbitmq_route_table.yaml"
         route_table = file_utils.load_yaml_conf(conf_path=route_table_path)
         mq = MQ(host, port, union_name, policy_id, route_table)
-        return Federation(federation_session_id, party, mq, rabbit_manager)
+        return Federation(federation_session_id, party, mq, rabbit_manager, max_message_size)
 
-    def __init__(self, session_id, party: Party, mq: MQ, rabbit_manager: RabbitManager):
+    def __init__(self, session_id, party: Party, mq: MQ, rabbit_manager: RabbitManager, max_message_size):
         self._session_id = session_id
         self._party = party
         self._mq = mq
@@ -95,8 +124,14 @@ class Federation(FederationABC):
 
         self._queue_map: typing.MutableMapping[Party, _QueueNames] = {}
         self._channels_map = {}
+<<<<<<< HEAD
      
     def get(self, name: str, tag: str, parties: typing.List[Party], gc: GarbageCollectionABC) -> typing.List:
+=======
+        self._max_message_size = max_message_size
+
+    def get(self, name, tag, parties: typing.List[Party], gc: GarbageCollectionABC) -> typing.List:
+>>>>>>> Finish the Update of RabbitMQ manager
         log_str = f"rabbitmq.get(name={name}, tag={tag}, parties={parties})"
         LOGGER.debug(f"[{log_str}]start to get")
 
@@ -133,7 +168,8 @@ class Federation(FederationABC):
             total_size = v.count()
             partitions = v.partitions
             LOGGER.debug(f"[{log_str}]start to remote RDD, total_size={total_size}, partitions={partitions}")
-            send_func = _get_partition_send_func(name, tag, total_size, partitions, mq_names, mq=self._mq)
+
+            send_func = _get_partition_send_func(name, tag, total_size, partitions, mq_names, mq=self._mq, maximun_message_size=self._max_message_size, connection_conf=self._rabbit_manager.runtime_config.get('connection', {}))
             # noinspection PyProtectedMember
             v._rdd.mapPartitions(send_func).count()
         else:
@@ -188,8 +224,15 @@ class Federation(FederationABC):
             self._rabbit_manager.federate_queue(upstream_host=upstream_uri, vhost=names.vhost,
                                                 send_queue_name=names.send, receive_queue_name=names.receive)
 
+<<<<<<< HEAD
             self._queue_map[name_party] = names
             LOGGER.debug(f"[rabbitmq.get_or_create_queue]queue for name: {name}, party:{party} created, names: {names}")
+=======
+            # TODO: check federated queue status
+
+            self._queue_map[party] = names
+            LOGGER.debug(f"[rabbitmq.get_or_create_queue]queue for party:{party} created, names: {names}")
+>>>>>>> Finish the Update of RabbitMQ manager
 
         names = self._queue_map[name_party]
         LOGGER.debug(f"[rabbitmq.get_or_create_queue]get queue: names: {names}")
@@ -207,15 +250,21 @@ class Federation(FederationABC):
             name, role, party_id = name_party.split("^")
             info = self._channels_map.get(name_party)
             if info is None:
+<<<<<<< HEAD
                 info = _get_channel(self._mq, names, party_id=party_id, role=role)
                 self._channels_map[name_party] = info
+=======
+                info = _get_channel(self._mq, names, party_id=party.party_id, role=party.role, connection_conf=self._rabbit_manager.runtime_config.get('connection', {}))
+                self._channels_map[party] = info
+>>>>>>> Finish the Update of RabbitMQ manager
             channel_infos.append(info)
         return channel_infos
 
 
-def _get_channel(mq, names: _QueueNames, party_id, role):
+def _get_channel(mq, names: _QueueNames, party_id, role, connection_conf: dict):
     return MQChannel(host=mq.host, port=mq.port, user=mq.union_name, password=mq.policy_id,
                      vhost=names.vhost, send_queue_name=names.send, receive_queue_name=names.receive, 
+<<<<<<< HEAD
                      party_id=party_id, role=role)
 
 # can't pickle _thread.lock objects
@@ -227,6 +276,9 @@ def _get_channels(mq_names, mq):
         channel_infos.append(info)
     return channel_infos
 
+=======
+                     party_id=party_id, role=role, extra_args=connection_conf)
+>>>>>>> Finish the Update of RabbitMQ manager
 
 def _send_kv(name, tag, data, channel_infos, total_size, partitions):
     headers = {"total_size": total_size, "partitions": partitions}
@@ -239,7 +291,7 @@ def _send_kv(name, tag, data, channel_infos, total_size, partitions):
             headers=headers
         )
         LOGGER.debug(f"[rabbitmq._send_kv]info: {info}, properties: {properties}.")
-        info.basic_publish(body=json.dumps(data), properties=properties)
+        info.basic_publish(body=data, properties=properties)
 
 
 def _send_obj(name, tag, data, channel_infos):
@@ -257,39 +309,43 @@ def _send_obj(name, tag, data, channel_infos):
 MESSAGE_MAX_SIZE = 50000
 
 # can't pickle _thread.lock objects
-def _get_channels(mq_names, mq):
+def _get_channels(mq_names, mq, connection_conf: dict):
     channel_infos = []
     for party, names in mq_names.items():
-        info = _get_channel(mq, names, party_id=party.party_id, role=party.role)
+        info = _get_channel(mq, names, party_id=party.party_id, role=party.role, connection_conf=connection_conf)
         channel_infos.append(info)
     return channel_infos
 
 
+<<<<<<< HEAD
+=======
 
-def _partition_snd(kvs, name, tag, total_size, partitions, mq_names, mq):
+>>>>>>> Finish the Update of RabbitMQ manager
+
+def _partition_snd(kvs, name, tag, total_size, partitions, mq_names, mq, maximun_message_size, connection_conf: dict):
     LOGGER.debug(
         f"[rabbitmq._partition_send]total_size:{total_size}, partitions:{partitions}, mq_names:{mq_names}, mq:{mq}.")
-    channel_infos = _get_channels(mq_names=mq_names, mq=mq)
-    data = []
-    lines = 0
+    channel_infos = _get_channels(mq_names=mq_names, mq=mq, connection_conf=connection_conf)
+
+    datastream = Datastream()
     for k, v in kvs:
         el = {'k': p_dumps(k).hex(), 'v': p_dumps(v).hex()}
-        data.append(el)
-        lines = lines + 1
-        if lines > MESSAGE_MAX_SIZE:
-            _send_kv(name=name, tag=tag, data=data, channel_infos=channel_infos,
+        # roughly caculate the size of package to avoid serialization ;)
+        if datastream.get_size() + sys.getsizeof(el['k']) + sys.getsizeof(el['v']) >= maximun_message_size:
+            LOGGER.debug(f'The size of message is: {datastream.get_size()}')
+            _send_kv(name=name, tag=tag, data=datastream.get_data(), channel_infos=channel_infos,
                      total_size=total_size, partitions=partitions)
-            lines = 0
-            data.clear()
-    _send_kv(name=name, tag=tag, data=data, channel_infos=channel_infos, total_size=total_size,
+            datastream.clear()
+        datastream.append(el)
+    _send_kv(name=name, tag=tag, data=datastream.get_data(), channel_infos=channel_infos, total_size=total_size,
              partitions=partitions)
     
     return [1]
 
 
-def _get_partition_send_func(name, tag, total_size, partitions, mq_names, mq):
+def _get_partition_send_func(name, tag, total_size, partitions, mq_names, mq, maximun_message_size, connection_conf: dict):
     def _fn(kvs):
-        return _partition_snd(kvs, name, tag, total_size, partitions, mq_names, mq)
+        return _partition_snd(kvs, name, tag, total_size, partitions, mq_names, mq, maximun_message_size, connection_conf)
 
     return _fn
 
@@ -325,7 +381,8 @@ def _receive(channel_info, name, tag):
            
         # rdd
         if properties.content_type == 'application/json':
-            data = json.loads(body)                
+            LOGGER.debug(f"[rabbitmq._receive] data: received data size is {sys.getsizeof(body)}")
+            data = json.loads(body)
             data_iter = ((p_loads(bytes.fromhex(el['k'])), p_loads(bytes.fromhex(el['v']))) for el in data)
             sc = SparkContext.getOrCreate()
             partitions = properties.headers["partitions"]

--- a/python/fate_arch/federation/rabbitmq/_federation.py
+++ b/python/fate_arch/federation/rabbitmq/_federation.py
@@ -76,9 +76,9 @@ class Federation(FederationABC):
         union_name = federation_info.get('union_name')
         policy_id = federation_info.get("policy_id")
 
-        rabbit_mq_run = runtime_conf.get('job_parameters', {}).get('rabbit_mq_run', {})
+        rabbitmq_run = runtime_conf.get('job_parameters', {}).get('rabbitmq_run', {})
 
-        rabbit_manager = RabbitManager(base_user, base_password, f"{host}:{mng_port}", rabbit_mq_run)
+        rabbit_manager = RabbitManager(base_user, base_password, f"{host}:{mng_port}", rabbitmq_run)
         rabbit_manager.create_user(union_name, policy_id)
         route_table_path = rabbitmq_config.get("route_table")
         if route_table_path is None:

--- a/python/fate_arch/federation/rabbitmq/_federation.py
+++ b/python/fate_arch/federation/rabbitmq/_federation.py
@@ -76,7 +76,9 @@ class Federation(FederationABC):
         union_name = federation_info.get('union_name')
         policy_id = federation_info.get("policy_id")
 
-        rabbit_manager = RabbitManager(base_user, base_password, f"{host}:{mng_port}")
+        rabbit_mq_run = runtime_conf.get('job_parameters', {}).get('rabbit_mq_run', {})
+
+        rabbit_manager = RabbitManager(base_user, base_password, f"{host}:{mng_port}", rabbit_mq_run)
         rabbit_manager.create_user(union_name, policy_id)
         route_table_path = rabbitmq_config.get("route_table")
         if route_table_path is None:

--- a/python/fate_arch/federation/rabbitmq/_mq_channel.py
+++ b/python/fate_arch/federation/rabbitmq/_mq_channel.py
@@ -23,7 +23,7 @@ LOGGER = log.getLogger()
 
 class MQChannel(object):
 
-    def __init__(self, host, port, user, password, vhost, send_queue_name, receive_queue_name, party_id, role):
+    def __init__(self, host, port, user, password, vhost, send_queue_name, receive_queue_name, party_id, role, extra_args: dict):
         self._host = host
         self._port = port
         self._credentials = pika.PlainCredentials(user, password)
@@ -34,6 +34,7 @@ class MQChannel(object):
         self._channel = None
         self._party_id = party_id
         self._role = role
+        self._extra_args = extra_args
 
     @property
     def party_id(self):
@@ -97,7 +98,8 @@ class MQChannel(object):
             if not self._conn:
                 self._conn = pika.BlockingConnection(pika.ConnectionParameters(host=self._host, port=self._port,
                                                                                virtual_host=self._vhost,
-                                                                               credentials=self._credentials))
+                                                                               credentials=self._credentials,
+                                                                               **self._extra_args))
             if not self._channel:
                 self._channel = self._conn.channel()
         except Exception as e:

--- a/python/fate_arch/federation/rabbitmq/_rabbit_manager.py
+++ b/python/fate_arch/federation/rabbitmq/_rabbit_manager.py
@@ -129,10 +129,18 @@ class RabbitManager:
 
         queue_runtime_config = self.runtime_config.get("queue", {})
         basic_config.update(queue_runtime_config)
+        LOGGER.debug(basic_config)
 
         result = requests.put(url, headers=C_COMMON_HTTP_HEADER,
                               json=basic_config, auth=(self.user, self.password))
         LOGGER.debug(result)
+        return result
+
+    def get_queue(self, vhost, queue_name):
+        url = C_HTTP_TEMPLATE.format(
+          self.endpoint, "{}/{}/{}".format("queues", vhost, queue_name))
+
+        result = requests.get(url, header=C_COMMON_HTTP_HEADER, auth=(self.user, self.password))
         return result
 
     def delete_queue(self, vhost, queue_name):

--- a/python/fate_arch/federation/rabbitmq/_rabbit_manager.py
+++ b/python/fate_arch/federation/rabbitmq/_rabbit_manager.py
@@ -18,10 +18,12 @@ APIs are refered to https://rawcdn.githack.com/rabbitmq/rabbitmq-management/v3.8
 
 
 class RabbitManager:
-    def __init__(self, user, password, endpoint):
+    def __init__(self, user, password, endpoint, runtime_config=None):
         self.user = user
         self.password = password
         self.endpoint = endpoint
+        # The runtime_config defines the parameters to create queue, exchange .etc
+        self.runtime_config = runtime_config if runtime_config is not None else {}
 
     # return a requests.Response object in case someone need more info about the Response
     def create_user(self, user, password):
@@ -30,7 +32,8 @@ class RabbitManager:
             "password": password,
             "tags": ""
         }
-        result = requests.put(url, headers=C_COMMON_HTTP_HEADER, json=body, auth=(self.user, self.password))
+        result = requests.put(url, headers=C_COMMON_HTTP_HEADER,
+                              json=body, auth=(self.user, self.password))
         LOGGER.debug(result)
         return result
 
@@ -42,7 +45,8 @@ class RabbitManager:
 
     def create_vhost(self, vhost):
         url = C_HTTP_TEMPLATE.format(self.endpoint, "vhosts/" + vhost)
-        result = requests.put(url, headers=C_COMMON_HTTP_HEADER, auth=(self.user, self.password))
+        result = requests.put(
+            url, headers=C_COMMON_HTTP_HEADER, auth=(self.user, self.password))
         LOGGER.debug(result)
         self.add_user_to_vhost(self.user, vhost)
         return result
@@ -60,19 +64,22 @@ class RabbitManager:
         return result
 
     def add_user_to_vhost(self, user, vhost):
-        url = C_HTTP_TEMPLATE.format(self.endpoint, "{}/{}/{}".format("permissions", vhost, user))
+        url = C_HTTP_TEMPLATE.format(
+            self.endpoint, "{}/{}/{}".format("permissions", vhost, user))
         body = {
             "configure": ".*",
             "write": ".*",
             "read": ".*"
         }
 
-        result = requests.put(url, headers=C_COMMON_HTTP_HEADER, json=body, auth=(self.user, self.password))
+        result = requests.put(url, headers=C_COMMON_HTTP_HEADER,
+                              json=body, auth=(self.user, self.password))
         LOGGER.debug(result)
         return result
 
     def remove_user_from_vhost(self, user, vhost):
-        url = C_HTTP_TEMPLATE.format(self.endpoint, "{}/{}/{}".format("permissions", vhost, user))
+        url = C_HTTP_TEMPLATE.format(
+            self.endpoint, "{}/{}/{}".format("permissions", vhost, user))
         result = requests.delete(url, auth=(self.user, self.password))
         LOGGER.debug(result)
         return result
@@ -84,9 +91,10 @@ class RabbitManager:
         return result
 
     def create_exchange(self, vhost, exchange_name):
-        url = C_HTTP_TEMPLATE.format(self.endpoint, "{}/{}/{}".format("exchanges", vhost, exchange_name))
+        url = C_HTTP_TEMPLATE.format(
+            self.endpoint, "{}/{}/{}".format("exchanges", vhost, exchange_name))
 
-        body = {
+        basic_config = {
             "type": "direct",
             "auto_delete": False,
             "durable": True,
@@ -94,31 +102,42 @@ class RabbitManager:
             "arguments": {}
         }
 
-        result = requests.put(url, headers=C_COMMON_HTTP_HEADER, json=body, auth=(self.user, self.password))
+        exchange_runtime_config = self.runtime_config.get("exchange", {})
+        basic_config.update(exchange_runtime_config)
+
+        result = requests.put(url, headers=C_COMMON_HTTP_HEADER,
+                              json=basic_config, auth=(self.user, self.password))
         LOGGER.debug(result)
         return result
 
     def delete_exchange(self, vhost, exchange_name):
-        url = C_HTTP_TEMPLATE.format(self.endpoint, "{}/{}/{}".format("exchanges", vhost, exchange_name))
+        url = C_HTTP_TEMPLATE.format(
+            self.endpoint, "{}/{}/{}".format("exchanges", vhost, exchange_name))
         result = requests.delete(url, auth=(self.user, self.password))
         LOGGER.debug(result)
         return result
 
     def create_queue(self, vhost, queue_name):
-        url = C_HTTP_TEMPLATE.format(self.endpoint, "{}/{}/{}".format("queues", vhost, queue_name))
+        url = C_HTTP_TEMPLATE.format(
+            self.endpoint, "{}/{}/{}".format("queues", vhost, queue_name))
 
-        body = {
+        basic_config = {
             "auto_delete": False,
             "durable": True,
             "arguments": {}
         }
 
-        result = requests.put(url, headers=C_COMMON_HTTP_HEADER, json=body, auth=(self.user, self.password))
+        queue_runtime_config = self.runtime_config.get("queue", {})
+        basic_config.update(queue_runtime_config)
+
+        result = requests.put(url, headers=C_COMMON_HTTP_HEADER,
+                              json=basic_config, auth=(self.user, self.password))
         LOGGER.debug(result)
         return result
 
     def delete_queue(self, vhost, queue_name):
-        url = C_HTTP_TEMPLATE.format(self.endpoint, "{}/{}/{}".format("queues", vhost, queue_name))
+        url = C_HTTP_TEMPLATE.format(
+            self.endpoint, "{}/{}/{}".format("queues", vhost, queue_name))
         result = requests.delete(url, auth=(self.user, self.password))
         LOGGER.debug(result)
         return result
@@ -134,7 +153,8 @@ class RabbitManager:
             "arguments": {}
         }
 
-        result = requests.post(url, headers=C_COMMON_HTTP_HEADER, json=body, auth=(self.user, self.password))
+        result = requests.post(
+            url, headers=C_COMMON_HTTP_HEADER, json=body, auth=(self.user, self.password))
         LOGGER.debug(result)
         return result
 
@@ -154,16 +174,19 @@ class RabbitManager:
                                                                          "federation-upstream",
                                                                          vhost,
                                                                          receive_queue_name))
+        upstream_runtime_config = self.runtime_config.get("upstream", {})
+
+        upstream_runtime_config['uri'] = upstream_host
+        upstream_runtime_config['queue'] = receive_queue_name.replace(
+            "receive", "send")
+
         body = {
-            "value":
-                {
-                    "uri": upstream_host,
-                    "queue": receive_queue_name.replace("receive", "send")
-                }
+            "value": upstream_runtime_config
         }
         LOGGER.debug(f"set_federated_upstream, url: {url} body: {body}")
 
-        result = requests.put(url, headers=C_COMMON_HTTP_HEADER, json=body, auth=(self.user, self.password))
+        result = requests.put(url, headers=C_COMMON_HTTP_HEADER,
+                              json=body, auth=(self.user, self.password))
         LOGGER.debug(result)
         return result
 
@@ -191,7 +214,8 @@ class RabbitManager:
         }
         LOGGER.debug(f"set_federated_queue_policy, url: {url} body: {body}")
 
-        result = requests.put(url, headers=C_COMMON_HTTP_HEADER, json=body, auth=(self.user, self.password))
+        result = requests.put(url, headers=C_COMMON_HTTP_HEADER,
+                              json=body, auth=(self.user, self.password))
         LOGGER.debug(result)
         return result
 
@@ -210,16 +234,18 @@ class RabbitManager:
         time.sleep(1)
         LOGGER.debug(f"create federate_queue {send_queue_name} {receive_queue_name}")
 
-        result_set_upstream = self._set_federated_upstream(upstream_host, vhost, receive_queue_name)
+        result_set_upstream = self._set_federated_upstream(
+            upstream_host, vhost, receive_queue_name)
 
-        result_set_policy = self._set_federated_queue_policy(vhost, receive_queue_name)
+        result_set_policy = self._set_federated_queue_policy(
+            vhost, receive_queue_name)
 
         if result_set_upstream.status_code != requests.codes.created:
             # should be loogged
             print("result_set_upstream fail.")
             print(result_set_upstream.text)
             # caller need to check None
-            # return None 
+            # return None
         elif result_set_policy.status_code != requests.codes.created:
             print("result_set_policy fail.")
             print(result_set_policy.text)
@@ -227,9 +253,11 @@ class RabbitManager:
 
     def de_federate_queue(self, vhost, receive_queue_name):
         result = self._unset_federated_queue_policy(receive_queue_name, vhost)
-        LOGGER.debug(f"delete federate queue policy status code: {result.status_code}")
+        LOGGER.debug(
+            f"delete federate queue policy status code: {result.status_code}")
 
         result = self._unset_federated_upstream(receive_queue_name, vhost)
-        LOGGER.debug(f"delete federate queue upstream status code: {result.status_code}")
+        LOGGER.debug(
+            f"delete federate queue upstream status code: {result.status_code}")
 
         return True

--- a/python/fate_flow/entity/types.py
+++ b/python/fate_flow/entity/types.py
@@ -37,6 +37,7 @@ class RunParameters(object):
         self.timeout = None
         self.eggroll_run = {}
         self.spark_run = {}
+        self.rabbitmq_run = {}
         self.adaptation_parameters = {}
         for k, v in kwargs.items():
             if hasattr(self, k):


### PR DESCRIPTION
Extend rabbitmq manager to support more runtime config.

A user can specify arguments for rabbitmq in runtime config of the job in this way:
```
{
    ...
   "job_parameters" : {
        "rabbitmq_run" : {
         "queue": {...},
         "upstream": {...},
         "connection": {...},
         "max_message_size": {...}
         }
    }
}
```
The parameters are described as follows:
- queue: parameters for queue creation
- upstream: parameters for setting federated upstream
- connection: parameters to config client-broker connections
- max_message_size: specify the limitation of message size to send