### PR TITLE
fix parameter merge problem, such as FeatureBinningParam transform_pa…

### DIFF
--- a/python/fate_flow/utils/parameter_util.py
+++ b/python/fate_flow/utils/parameter_util.py
@@ -182,9 +182,9 @@ class BaseParameterUtil(object):
                     runtime_dict[key] = {}
 
                 runtime_dict[key] = ParameterUtil.merge_parameters(runtime_dict.get(key),
-                                                                   val_list,
+                                                                   val_list[idx],
                                                                    attr,
-                                                                   idx,
+                                                                   -1,
                                                                    role=role,
                                                                    role_num=role_num,
                                                                    component=component,


### PR DESCRIPTION
支持下面这种类型的组件解析，例如transform_param参数，可以和别的保持一致
"hetero_feature_binning_0": {
    "method": ["quantile"],
    "compress_thres": [10000],
    "head_size": [10000],
    "error": [0.0001],
    "bin_num": [10],
    "cols": [-1],
    "adjustment_factor": [0.5],
    "local_only": [false],
    "transform_param": [{
      "transform_cols": -1,
      "transform_type": "bin_num"
    }]
}
目前fate只支持以下这种
"hetero_feature_binning_0": {
    "method": ["quantile"],
    "compress_thres": [10000],
    "head_size": [10000],
    "error": [0.0001],
    "bin_num": [10],
    "cols": [-1],
    "adjustment_factor": [0.5],
    "local_only": [false],
    "transform_param": {
      "transform_cols": [-1],
      "transform_type": ["bin_num"]
    }
}

