### PR TITLE
add environment variable `FATE_DEPLOY_BASE`

### DIFF
--- a/python/fate_arch/common/file_utils.py
+++ b/python/fate_arch/common/file_utils.py
@@ -21,14 +21,20 @@ from cachetools import LRUCache
 from cachetools import cached
 from ruamel import yaml
 
-PROJECT_BASE = None
+PROJECT_BASE = os.getenv("FATE_DEPLOY_BASE")
 
 
 def get_project_base_directory():
     global PROJECT_BASE
     if PROJECT_BASE is None:
         PROJECT_BASE = os.path.abspath(
-            os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir, os.pardir, os.pardir))
+            os.path.join(
+                os.path.dirname(os.path.realpath(__file__)),
+                os.pardir,
+                os.pardir,
+                os.pardir,
+            )
+        )
     return PROJECT_BASE
 
 
@@ -46,7 +52,9 @@ def load_json_conf(conf_path):
         with open(json_conf_path) as f:
             return json.load(f)
     except:
-        raise EnvironmentError("loading json file config from '{}' failed!".format(json_conf_path))
+        raise EnvironmentError(
+            "loading json file config from '{}' failed!".format(json_conf_path)
+        )
 
 
 def dump_json_conf(config_data, conf_path):
@@ -58,7 +66,9 @@ def dump_json_conf(config_data, conf_path):
         with open(json_conf_path, "w") as f:
             json.dump(config_data, f, indent=4)
     except:
-        raise EnvironmentError("loading json file config from '{}' failed!".format(json_conf_path))
+        raise EnvironmentError(
+            "loading json file config from '{}' failed!".format(json_conf_path)
+        )
 
 
 def load_json_conf_real_time(conf_path):
@@ -70,7 +80,9 @@ def load_json_conf_real_time(conf_path):
         with open(json_conf_path) as f:
             return json.load(f)
     except:
-        raise EnvironmentError("loading json file config from '{}' failed!".format(json_conf_path))
+        raise EnvironmentError(
+            "loading json file config from '{}' failed!".format(json_conf_path)
+        )
 
 
 def load_yaml_conf(conf_path):
@@ -80,7 +92,9 @@ def load_yaml_conf(conf_path):
         with open(conf_path) as f:
             return yaml.safe_load(f)
     except Exception as e:
-        raise EnvironmentError("loading yaml file config from {} failed:".format(conf_path), e)
+        raise EnvironmentError(
+            "loading yaml file config from {} failed:".format(conf_path), e
+        )
 
 
 def rewrite_yaml_conf(conf_path, config):
@@ -90,10 +104,12 @@ def rewrite_yaml_conf(conf_path, config):
         with open(conf_path, "w") as f:
             yaml.dump(config, f, Dumper=yaml.RoundTripDumper)
     except Exception as e:
-        raise EnvironmentError("rewrite yaml file config {} failed:".format(conf_path), e)
+        raise EnvironmentError(
+            "rewrite yaml file config {} failed:".format(conf_path), e
+        )
 
 
 def rewrite_json_file(filepath, json_data):
-    with open(filepath, 'w') as f:
-        json.dump(json_data, f, indent=4, separators=(',', ': '))
+    with open(filepath, "w") as f:
+        json.dump(json_data, f, indent=4, separators=(",", ": "))
     f.close()

--- a/python/fate_flow/service.sh
+++ b/python/fate_flow/service.sh
@@ -16,7 +16,11 @@
 #  limitations under the License.
 #
 
-PROJECT_BASE=$(cd "$(dirname "$0")";cd ../;cd ../;pwd)
+if [[ -z "${FATE_DEPLOY_BASE}" ]]; then
+    PROJECT_BASE=$(cd "$(dirname "$0")";cd ../;cd ../;pwd)
+else
+    PROJECT_BASE="${FATE_DEPLOY_BASE}"
+fi
 echo "PROJECT_BASE: "${PROJECT_BASE}
 
 # source init_env.sh
@@ -98,9 +102,13 @@ start() {
     if [[ ${pid} == "" ]]; then
         mklogsdir
         if [[ $1x == "front"x ]];then
+          export FATE_DEPLOY_BASE=${PROJECT_BASE}
           exec python ${PROJECT_BASE}/python/fate_flow/fate_flow_server.py >> "${log_dir}/console.log" 2>>"${log_dir}/error.log"
+          unset FATE_DEPLOY_BASE
         else
+          export FATE_DEPLOY_BASE=${PROJECT_BASE}
           nohup python ${PROJECT_BASE}/python/fate_flow/fate_flow_server.py >> "${log_dir}/console.log" 2>>"${log_dir}/error.log" &
+          unset FATE_DEPLOY_BASE
         fi
         for((i=1;i<=100;i++));
         do


### PR DESCRIPTION
Signed-off-by: weiwee <wbwmat@gmail.com>

-------

Changes:

1. FATE could infer fate base directory from environment variable `FATE_DEPLOY_BASE`

Reason:

make it possible to deploy `FATE` to different directory other than `source code directory` with symlink and keep source code directory clean

1. copy bin and conf directory to deploy base directory
2. add soft symlink to `source` directories and files: examples, python and fate.env 

deploy directory structure:
``` sh
Permissions Size User Date Modified Name
drwxr-xr-x     - sage  6 Feb 19:53  bin
drwxr-xr-x     - sage  6 Feb 19:53  conf
lrwxr-xr-x    25 sage  6 Feb 19:56  examples -> /Users/sage/FATE/examples
lrwxr-xr-x    25 sage  6 Feb 19:57  fate.env -> /Users/sage/FATE/fate.env
lrwxr-xr-x    23 sage  6 Feb 19:52  python -> /Users/sage/FATE/python
```

deploy directory structure after some jobs submitted:

``` sh
Permissions Size User Date Modified Name
drwxr-xr-x     - sage  6 Feb 19:53  bin
drwxr-xr-x     - sage  6 Feb 19:53  conf
drwxr-xr-x     - sage  6 Feb 22:12  data
lrwxr-xr-x    25 sage  6 Feb 19:56  examples -> /Users/sage/FATE/examples
lrwxr-xr-x    25 sage  6 Feb 19:57  fate.env -> /Users/sage/FATE/fate.env
.rw-r--r--  814k sage  6 Feb 22:12  fate_flow_sqlite.db
drwxr-xr-x     - sage  6 Feb 22:12  jobs
drwxr-xr-x     - sage  6 Feb 22:12  logs
drwxr-xr-x     - sage  6 Feb 22:12  model_local_cache
lrwxr-xr-x    23 sage  6 Feb 19:52  python -> /Users/sage/FATE/python

```