### PR TITLE
Fix misleading annotation of subsample_feature_rate

### DIFF
--- a/python/fate_client/pipeline/param/boosting_param.py
+++ b/python/fate_client/pipeline/param/boosting_param.py
@@ -211,7 +211,7 @@ class BoostingParam(BaseParam):
 
         num_trees : int, accepted int, float only, the max number of boosting round. default: 5
 
-        subsample_feature_rate : float, a float-number in [0, 1], default: 0.8
+        subsample_feature_rate : float, a float-number in [0, 1], default: 1.0
 
         n_iter_no_change : bool,
             when True and residual error less than tol, tree building process will stop. default: True
@@ -366,7 +366,7 @@ class HeteroSecureBoostParam(HeteroBoostingParam):
 
         num_trees : int, accepted int, float only, the max number of trees to build. default: 5
 
-        subsample_feature_rate : float, a float-number in [0, 1], default: 0.8
+        subsample_feature_rate : float, a float-number in [0, 1], default: 1.0
 
         subsample_random_seed: seed that controls feature subsample
 

--- a/python/federatedml/param/boosting_param.py
+++ b/python/federatedml/param/boosting_param.py
@@ -211,7 +211,7 @@ class BoostingParam(BaseParam):
 
         num_trees : int, accepted int, float only, the max number of boosting round. default: 5
 
-        subsample_feature_rate : float, a float-number in [0, 1], default: 0.8
+        subsample_feature_rate : float, a float-number in [0, 1], default: 1.0
 
         n_iter_no_change : bool,
             when True and residual error less than tol, tree building process will stop. default: True
@@ -366,7 +366,7 @@ class HeteroSecureBoostParam(HeteroBoostingParam):
 
         num_trees : int, accepted int, float only, the max number of trees to build. default: 5
 
-        subsample_feature_rate : float, a float-number in [0, 1], default: 0.8
+        subsample_feature_rate : float, a float-number in [0, 1], default: 1.0
 
         subsample_random_seed: seed that controls feature subsample
 


### PR DESCRIPTION
Change the default value to 1.0 in subsample_feature_rate's annotation for the coherence value in code.


