### PR TITLE
fix: docker build of python-nn

### DIFF
--- a/docker-build/docker/modules/python-nn/Dockerfile
+++ b/docker-build/docker/modules/python-nn/Dockerfile
@@ -3,4 +3,4 @@ ARG PREFIX=prefix
 ARG BASE_TAG=tag
 FROM ${PREFIX}/python:${BASE_TAG}
 
-RUN pip install torch==1.4.0 tensorflow==1.15.4 torchvision==0.5.0
+RUN pip install torch==1.4.0 tensorflow>=1.15.4 torchvision==0.5.0


### PR DESCRIPTION
Signed-off-by: ChenLong Ma <owlet42@126.com>

The tensorflow version of python-nn Dockerfile is inconsistent with requirements.txt, causing docker build to report an error.
