### PR TITLE
Update eggroll dockerfile: install strace

### DIFF
--- a/docker-build/docker/modules/eggroll/Dockerfile
+++ b/docker-build/docker/modules/eggroll/Dockerfile
@@ -5,7 +5,7 @@ FROM ${PREFIX}/base-image:${BASE_TAG}
 RUN set -eux; \
     rpm --rebuilddb; \
     rpm --import /etc/pki/rpm-gpg/RPM*; \
-    yum install -y which java-1.8.0-openjdk java-1.8.0-openjdk-devel ; \
+    yum install -y which strace java-1.8.0-openjdk java-1.8.0-openjdk-devel ; \
     yum clean all;
 
 WORKDIR /data/projects/fate/eggroll/


### PR DESCRIPTION
`egg_pair_bootstrap.sh` use `strace` to record system call. 
But eggroll image haven't install the command yet.

https://github.com/WeBankFinTech/eggroll/blob/3f13c7aba12af3cec1002735e915040174dd1867/bin/roll_pair/egg_pair_bootstrap.sh#L185
