### PR TITLE
Feature 1.7 deploy homo model: fate_flow changes

### DIFF
--- a/python/fate_flow/apps/model_app.py
+++ b/python/fate_flow/apps/model_app.py
@@ -736,6 +736,23 @@ def homo_convert():
     return get_json_result(retcode=retcode, retmsg=retmsg, data=res_data)
 
 
+@manager.route('/homo/deploy', methods=['POST'])
+def homo_deploy():
+    request_config = request.json or request.form.to_dict()
+    required_arguments = ["service_id",
+                          "model_id",
+                          "model_version",
+                          "role",
+                          "party_id",
+                          "component_name",
+                          "deployment_type",
+                          "deployment_parameters"]
+    check_config(request_config, required_arguments=required_arguments)
+    retcode, retmsg, res_data = publish_model.deploy_homo_model(request_data=request_config)
+    operation_record(request.json, "homo_deploy", "success" if not retcode else "failed")
+    return get_json_result(retcode=retcode, retmsg=retmsg, data=res_data)
+
+
 def adapter_servings_config(request_data):
     servings_conf = ServiceUtils.get("servings", {})
     if isinstance(servings_conf, dict):

--- a/python/fate_flow/doc/fate_flow_http_api.rst
+++ b/python/fate_flow/doc/fate_flow_http_api.rst
@@ -709,6 +709,28 @@ Model
    -  data: predict config of specified model, Object
 
 
+/v1/model/homo/deploy
+~~~~~~~~~~~~~~~~~~
+
+-  request structure
+
+   - service_id: Required, String: service id
+   - model_version: Required, Integer: model version
+   - model_id: Required, String: model id
+   - role: Required, String: role
+   - party_id: Required, String: party id
+   - component_name: Required, String: component name
+   - framework_name: Optional, String: the target machine learning framework this serving service is for, will be inferred automatically if it is empty
+   - deployment_type: Required, String: type of the serving service, only "kfserving" is allowed currently
+   - deployment_parameters: Required, Object: parameters that will be configured for the serving service
+
+-  response structure
+
+   -  retcode: return code, Integer
+   -  retmsg: return code description, String
+   -  data: detailed info of the deployed serving service, Object
+
+
 
 Table
 -----

--- a/python/fate_flow/examples/homo_deploy_model.json
+++ b/python/fate_flow/examples/homo_deploy_model.json
@@ -1,0 +1,24 @@
+{
+  "service_id": "sklearn-lr",
+  "role": "guest",
+  "party_id": 9999,
+  "model_id": "arbiter-10000#guest-9999#host-10000#model",
+  "model_version": "202006122009345696314",
+  "component_name": "homo_lr_0",
+  "deployment_type": "kfserving",
+  "deployment_parameters" : {
+    "protocol_version": "v1",
+    "namespace": "default",
+    "config_file_content": "<content of kube_config file>",
+    "replace": false,
+    "skip_create_storage_secret": false,
+    "model_storage_type": "minio",
+    "model_storage_parameters": {
+      "endpoint": "minio:9000",
+      "access_key": "",
+      "secret_key": "",
+      "secure": false,
+      "region": ""
+    }
+  }
+}

--- a/python/fate_flow/examples/homo_deploy_model.json
+++ b/python/fate_flow/examples/homo_deploy_model.json
@@ -1,9 +1,9 @@
 {
   "service_id": "sklearn-lr",
-  "role": "guest",
-  "party_id": 9999,
   "model_id": "arbiter-10000#guest-9999#host-10000#model",
   "model_version": "202006122009345696314",
+  "role": "guest",
+  "party_id": 9999,
   "component_name": "homo_lr_0",
   "deployment_type": "kfserving",
   "deployment_parameters" : {

--- a/python/fate_flow/pipelined_model/homo_model_deployer/__init__.py
+++ b/python/fate_flow/pipelined_model/homo_model_deployer/__init__.py
@@ -1,0 +1,15 @@
+#
+#  Copyright 2021 The FATE Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#

--- a/python/fate_flow/pipelined_model/homo_model_deployer/kfserving/__init__.py
+++ b/python/fate_flow/pipelined_model/homo_model_deployer/kfserving/__init__.py
@@ -1,0 +1,55 @@
+#
+#  Copyright 2021 The FATE Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+
+from .pytorch import TorchServeKFDeployer
+from .sklearn import SKLearnV1KFDeployer, SKLearnV2KFDeployer
+from .tensorflow import TFServingKFDeployer
+
+
+def get_kfserving_deployer(party_model_id,
+                           model_version,
+                           model_object,
+                           framework_name,
+                           service_id,
+                           protocol_version="v1",
+                           **kwargs):
+    """
+    Returns a deployer for KFServing InferenceService
+
+    Refer to KFServingDeployer and its sub-classes
+    for supported kwargs.
+    :param party_model_id: the model id with party info used to identify the model
+    :param model_version: the model version
+    :param model_object: the converted model object
+    :param framework_name: the framework of the model_object
+    :param service_id: name of the serving service, will be used in KFServing as the service name
+    :param protocol_version: the protocol version, currently only scikit-learn model supports v2
+    :param kwargs: keyword argument to initialize the deployer object
+    :return: an instance of the subclass of the base KFServingDeployer
+    """
+    if framework_name in ['sklearn', 'scikit-learn']:
+        if protocol_version == "v2":
+            cls = SKLearnV2KFDeployer
+        else:
+            cls = SKLearnV1KFDeployer
+    elif framework_name in ['pytorch', 'torch']:
+        cls = TorchServeKFDeployer
+    elif framework_name in ['tf_keras', 'tensorflow', 'tf']:
+        cls = TFServingKFDeployer
+    else:
+        raise ValueError("unknown converted model framework: {}".format(framework_name))
+    return cls(party_model_id, model_version, model_object, service_id, **kwargs)

--- a/python/fate_flow/pipelined_model/homo_model_deployer/kfserving/_dummy_base_handler.py
+++ b/python/fate_flow/pipelined_model/homo_model_deployer/kfserving/_dummy_base_handler.py
@@ -1,0 +1,22 @@
+#
+#  Copyright 2021 The FATE Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+# This file won't be loaded in fate_flow but will be packaged into the torch model archive
+from ts.torch_handler.base_handler import BaseHandler
+
+
+class DummyHandler(BaseHandler):
+    pass

--- a/python/fate_flow/pipelined_model/homo_model_deployer/kfserving/base.py
+++ b/python/fate_flow/pipelined_model/homo_model_deployer/kfserving/base.py
@@ -1,0 +1,225 @@
+#
+#  Copyright 2021 The FATE Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import io
+import uuid
+import kfserving
+from kfserving.api import creds_utils
+from kubernetes import client
+
+from fate_flow.settings import stat_logger
+from .model_storage import get_model_storage, ModelStorageType
+from .model_storage.minio import MinIOModelStorage
+
+MINIO_K8S_SECRET_NAME = "fate-homo-serving-minio-secret"
+
+STORAGE_URI_KEY = "storage_uri"
+
+ANNOTATION_PREFIX = "fate.fedai.org/"
+ANNOTATION_SERVICE_UUID = ANNOTATION_PREFIX + "uuid"
+ANNOTATION_FATE_MODEL_ID = ANNOTATION_PREFIX + "model_id"
+ANNOTATION_FATE_MODEL_VERSION = ANNOTATION_PREFIX + "model_version"
+
+
+class KFServingDeployer(object):
+    """Class representing a KFServing service deployer
+    """
+
+    def __init__(self,
+                 party_model_id,
+                 model_version,
+                 model_object,
+                 service_id,
+                 namespace=None,
+                 config_file_content=None,
+                 replace=False,
+                 skip_create_storage_secret=False,
+                 model_storage_type=ModelStorageType.MINIO,
+                 model_storage_parameters=None):
+        """
+        :param party_model_id: the model id with party info used to identify the model
+        :param model_version: the model version
+        :param model_object: the converted model object
+        :param service_id: name of the service
+        :param config_file_content: the content of a config file that will be used to connect to the
+                                    kubernetes cluster.
+        :param namespace: the kubernetes namespace this service belongs to.
+        :param replace: whether to replace the running service, defaults to False.
+        :param skip_create_storage_secret: whether or not to skip setting up MinIO credentials for
+                                           KFServing storage-initializer container, defaults to False.
+        :param model_storage_type: type of the underlying model storage
+                                   defaults to ModelStorageType.MINIO.
+        :param model_storage_parameters: a dict containing extra arguments to initialize the
+                                         model storage instance, defaults to {}.
+                                         see the doc of model storage classes for the available
+                                         parameters.
+        """
+        self.party_model_id = party_model_id
+        self.model_version = model_version
+        self.model_object = model_object
+        self.service_id = service_id
+        if model_storage_parameters is None:
+            model_storage_parameters = {}
+        self.model_storage = get_model_storage(storage_type=model_storage_type,
+                                               sub_path=party_model_id + "/" + model_version + "/" + service_id,
+                                               **model_storage_parameters)
+        self.storage_uri = None
+        self.isvc = None
+        # this should also set up kubernetes.client config
+        config_file = None
+        if config_file_content:
+            config_file = io.StringIO(config_file_content)
+        self.kfserving_client = kfserving.KFServingClient(config_file)
+        self.namespace = namespace if namespace else kfserving.utils.get_default_target_namespace()
+        self.replace = replace
+        self.skip_create_storage_secret = skip_create_storage_secret
+        stat_logger.debug("Initialized KFServingDeployer with client config: {}".format(config_file))
+
+    def prepare_model(self):
+        """
+        Prepare the model to be used by KFServing system.
+
+        Calls into each deployer implementation to serialize the model object
+        and uploads the related files to the target model storage.
+
+        :return: the uri to fetch the uploaed/prepared model
+        """
+        if not self.storage_uri:
+            self.storage_uri = self.model_storage.save(self._do_prepare_model())
+        stat_logger.info("Prepared model with uri: {}".format(self.storage_uri))
+        return self.storage_uri
+
+    def _do_prepare_model(self):
+        raise NotImplementedError("_do_prepare_storage method not implemented")
+
+    def deploy(self):
+        """
+        Deploy a KFServing InferenceService from a model object
+
+        :return: the InferenceService object as a dict
+        """
+        if self.status() and not self.replace:
+            raise RuntimeError("serving service {} already exists".format(self.service_id))
+
+        if self.isvc is None:
+            stat_logger.info("Preparing model storage and InferenceService spec...")
+            self.prepare_model()
+            self.prepare_isvc()
+        if self.isvc.metadata.annotations is None:
+            self.isvc.metadata.annotations = {}
+        # add a different annotation to force replace
+        self.isvc.metadata.annotations[ANNOTATION_SERVICE_UUID] = str(uuid.uuid4())
+        self.isvc.metadata.annotations[ANNOTATION_FATE_MODEL_ID] = self.party_model_id
+        self.isvc.metadata.annotations[ANNOTATION_FATE_MODEL_VERSION] = self.model_version
+
+        if isinstance(self.model_storage, MinIOModelStorage) and not self.skip_create_storage_secret:
+            self.prepare_sa_secret()
+
+        if self.status() is None:
+            stat_logger.info("Creating InferenceService {}...".format(self.service_id))
+            created_isvc = self.kfserving_client.create(self.isvc, namespace=self.namespace)
+        else:
+            stat_logger.info("Replacing InferenceService {}...".format(self.service_id))
+            self.isvc.metadata.resource_version = None
+            created_isvc = self.kfserving_client.replace(self.service_id, self.isvc,
+                                                         namespace=self.namespace)
+        return created_isvc
+
+    def prepare_isvc(self):
+        """
+        Generate an InferenceService spec to be applied into KFServing
+
+        :return: the spec object
+        """
+        if self.isvc is None:
+            self.isvc = kfserving.V1beta1InferenceService(
+                api_version=kfserving.constants.KFSERVING_V1BETA1,
+                kind=kfserving.constants.KFSERVING_KIND,
+                metadata=client.V1ObjectMeta(name=self.service_id),
+                spec=kfserving.V1beta1InferenceServiceSpec(
+                    predictor=kfserving.V1beta1PredictorSpec()))
+            self._do_prepare_predictor()
+            if self.namespace:
+                self.isvc.metadata.namespace = self.namespace
+        stat_logger.info("InferenceService spec ready")
+        stat_logger.debug(self.isvc)
+        return self.isvc
+
+    def _do_prepare_predictor(self):
+        raise NotImplementedError("_do_prepare_predictor method not implemented")
+
+    def destroy(self):
+        """
+        Delete the InferenceService
+        """
+        if self.status() is not None:
+            self.kfserving_client.delete(self.service_id, namespace=self.namespace)
+            stat_logger.info("InferenceService {} is deleted".format(self.service_id))
+
+    def status(self):
+        try:
+            return self.kfserving_client.get(self.service_id, namespace=self.namespace)
+        except RuntimeError as e:
+            if "Reason: Not Found" in str(e):
+                return None
+
+    def wait(self, timeout=120):
+        """Wait until the service becomes ready
+
+        Internally calls KFServing API to retrieve the status
+
+        :param timeout: seconds to wait
+        :return: the InferenceService dict
+        """
+        return self.kfserving_client.get(self.service_id,
+                                         namespace=self.namespace,
+                                         watch=True,
+                                         timeout_seconds=timeout)
+
+    def prepare_sa_secret(self):
+        """
+        Prepare the secret to be used by the service account for the KFServing service.
+
+        KFServing needs a service account to find the credential to download files
+        from MINIO/S3 storage. It must contain a secret resource with the credential
+        embedded. We can prepare one use kubernetes API here.
+        """
+        secrets = client.CoreV1Api().list_namespaced_secret(self.namespace)
+        secret_names = [secret.metadata.name for secret in secrets.items]
+        annotations = {
+            "serving.kubeflow.org/s3-endpoint": self.model_storage.endpoint,
+            "serving.kubeflow.org/s3-usehttps": "1" if self.model_storage.secure else "0"
+        }
+        secret = client.V1Secret(metadata=client.V1ObjectMeta(name=MINIO_K8S_SECRET_NAME,
+                                                              annotations=annotations),
+                                 type="Opaque",
+                                 string_data={
+                                     'AWS_ACCESS_KEY_ID': self.model_storage.access_key,
+                                     'AWS_SECRET_ACCESS_KEY': self.model_storage.secret_key
+                                 })
+        if MINIO_K8S_SECRET_NAME not in secret_names:
+            client.CoreV1Api().create_namespaced_secret(self.namespace, secret)
+        else:
+            client.CoreV1Api().patch_namespaced_secret(MINIO_K8S_SECRET_NAME, self.namespace, secret)
+
+        sa_name = self.isvc.spec.predictor.service_account_name \
+            if (self.isvc and
+                isinstance(self.isvc, kfserving.V1beta1InferenceService) and
+                self.isvc.spec.predictor.service_account_name) \
+            else "default"
+        creds_utils.set_service_account(self.namespace,
+                                        sa_name,
+                                        MINIO_K8S_SECRET_NAME)

--- a/python/fate_flow/pipelined_model/homo_model_deployer/kfserving/model_storage/__init__.py
+++ b/python/fate_flow/pipelined_model/homo_model_deployer/kfserving/model_storage/__init__.py
@@ -1,0 +1,39 @@
+#
+#  Copyright 2021 The FATE Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+from enum import Enum
+
+from .minio import MinIOModelStorage
+
+
+class ModelStorageType(Enum):
+    MINIO = 1
+
+
+def get_model_storage(storage_type=ModelStorageType.MINIO, **kwargs):
+    """
+    get a model storage insance based on the specified type
+
+    :param storage_type: type of the model storage, currently only MINIO is supported
+    :param kwargs: keyword arguments to initialize the model storage object
+    :return: an instance of a subclass of BaseModelStorage
+    """
+    if isinstance(storage_type, str):
+        storage_type = ModelStorageType[storage_type.upper()]
+    if storage_type == ModelStorageType.MINIO:
+        return MinIOModelStorage(**kwargs)
+    else:
+        raise ValueError("unknown model storage type: {}".format(storage_type))

--- a/python/fate_flow/pipelined_model/homo_model_deployer/kfserving/model_storage/base.py
+++ b/python/fate_flow/pipelined_model/homo_model_deployer/kfserving/model_storage/base.py
@@ -1,0 +1,20 @@
+#
+#  Copyright 2021 The FATE Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+
+class BaseModelStorage(object):
+    def save(self, model_object, dest):
+        pass

--- a/python/fate_flow/pipelined_model/homo_model_deployer/kfserving/model_storage/minio.py
+++ b/python/fate_flow/pipelined_model/homo_model_deployer/kfserving/model_storage/minio.py
@@ -1,0 +1,175 @@
+#
+#  Copyright 2021 The FATE Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import os
+from urllib.parse import urlparse
+from minio import Minio
+
+from fate_flow.settings import stat_logger
+from .base import BaseModelStorage
+
+
+ENV_MINIO_ENDPOINT_URL = "MINIO_ENDPOINT_URL"
+ENV_MINIO_ACCESS_KEY_ID = "MINIO_ACCESS_KEY_ID"
+ENV_MINIO_SECRET_ACCESS_KEY = "MINIO_SECRET_ACCESS_KEY"
+ENV_MINIO_USE_HTTPS = "MINIO_USE_HTTPS"
+ENV_MINIO_REGION = "MINIO_REGION"
+
+
+class MinIOModelStorage(BaseModelStorage):
+    """Model storage to upload model object into MinIO
+
+    If not specified by the caller, the following environment
+    variables will be used to connect to the server:
+    MINIO_ENDPOINT_URL, MINIO_ACCESS_KEY_ID, MINIO_SECRET_ACCESS_KEY
+    MINIO_USE_HTTPS, MINIO_REGION.
+    """
+
+    def __init__(self,
+                 sub_path="",
+                 bucket="fate-models",
+                 endpoint=None,
+                 access_key=None,
+                 secret_key=None,
+                 region=None,
+                 secure=True):
+        """
+        :param sub_path: sub path within the bucket, defaults to ""
+        :param bucket: bucket to store the model, defaults to "fate_models"
+        :param endpoint: server endpoint, defaults to None
+        :param access_key: access key, defaults to None
+        :param secret_key: secret key, defaults to None
+        :param region: region name, defaults to None
+        :param secure: flag to indicate whether tls should be used, defaults to True
+        """
+        super(MinIOModelStorage, self).__init__()
+        self.bucket = bucket
+        self.sub_path = sub_path
+
+        if not endpoint:
+            url = urlparse(os.getenv(ENV_MINIO_ENDPOINT_URL, "http://minio:9000"))
+            secure = url.scheme == 'https' if url.scheme else bool(os.getenv(ENV_MINIO_USE_HTTPS, "true"))
+            endpoint = url.netloc
+            access_key = os.getenv(ENV_MINIO_ACCESS_KEY_ID)
+            secret_key = os.getenv(ENV_MINIO_SECRET_ACCESS_KEY)
+            region = os.getenv(ENV_MINIO_REGION)
+
+        stat_logger.debug("Initialized MinIOModelStorage with endpoint: {}, "
+                          "access_key: {}, region: {}, with TLS: {}"
+                          .format(endpoint, access_key, region, secure))
+        self.endpoint = endpoint
+        self.access_key = access_key
+        self.secret_key = secret_key
+        self.region = region
+        self.secure = secure
+
+        self.client = Minio(
+            endpoint,
+            access_key=access_key,
+            secret_key=secret_key,
+            region=region,
+            secure=secure
+        )
+
+    def save(self, model_object, dest=""):
+        """
+        Upload the model objects to the specified destination path
+
+        If the dest parameter is empty, the target file/object name
+        will be inferred from the local files.
+
+        :param model_object: pointer to the file(s) to be uploaded
+        :param dest: the destination file/object name
+        :return:
+        """
+        stat_logger.debug("Upload model object: {} of type: {}"
+                          .format(model_object, type(model_object)))
+        # If the model object is already a local file then we
+        # just upload it.
+        if isinstance(model_object, str):
+            if os.path.isfile(model_object):
+                return self.upload_file(model_object, dest)
+            elif os.path.isdir(model_object):
+                return self.upload_folder(model_object, dest)
+            else:
+                raise ValueError("expect an existing path, got: {}".format(model_object))
+        elif isinstance(model_object, list):
+            for obj in model_object:
+                if 'dest' not in obj:
+                    obj['dest'] = os.path.basename(obj['file'])
+            return self.upload_objects(model_object)
+        elif isinstance(model_object, dict) and "dest" in model_object \
+                and "file" in model_object and isinstance(model_object['file'], str):
+            return self.upload_objects([model_object])
+        else:
+            raise ValueError("unsupported object type {}".format(type(model_object)))
+
+    def upload_folder(self, folder, dest=""):
+        files_to_upload = []
+        for dir_, _, files in os.walk(folder):
+            for file_name in files:
+                rel_dir = os.path.relpath(dir_, folder).lstrip("./")
+                rel_dest = os.path.join(rel_dir, file_name)
+                if dest:
+                    rel_dest = dest + "/" + rel_dest
+                file = os.path.join(dir_, file_name)
+                files_to_upload.append({"dest": rel_dest, "obj": file})
+        return self.upload_objects(files_to_upload)
+
+    def upload_file(self, file, dest=""):
+        if not dest:
+            dest = os.path.basename(file)
+        return self.upload_objects([{"dest": dest, "obj": file}])
+
+    def upload_readable_obj(self, dest, obj, length):
+        return self.upload_objects([{"dest": dest,
+                                     "obj": obj,
+                                     "length": length
+                                     }])
+
+    def upload_objects(self, objects):
+        """
+        Perform the uploading.
+
+        Each element in the objects list should be a dict that looks:
+
+        {
+            "obj": <path to a local file or a file-like object>
+            "dest": <target file name under "subpath">
+            "length": <for a file-like object, length in bytes of the file-like object content>
+        }
+
+        :param objects: a list of object to be uploaded.
+        :return: the complete "s3://" type uri for the sub-path to local all the uploaded objects
+        """
+        client = self.client
+        bucket = self.bucket
+        found = client.bucket_exists(bucket)
+        if not found:
+            client.make_bucket(bucket)
+
+        for obj in objects:
+            dest = self.sub_path + "/" + obj['dest']
+            file = obj['obj']
+            stat_logger.debug("Uploading {} to {}".format(file, dest))
+            if hasattr(file, 'read'):
+                length = obj['length']
+                client.put_object(bucket, dest, file, length)
+            else:
+                client.fput_object(bucket, dest, file)
+        model_path = f's3://{bucket}/{self.sub_path}'
+        stat_logger.info("Uploaded model objects into path: {}".format(model_path))
+        return model_path

--- a/python/fate_flow/pipelined_model/homo_model_deployer/kfserving/pytorch.py
+++ b/python/fate_flow/pipelined_model/homo_model_deployer/kfserving/pytorch.py
@@ -1,0 +1,119 @@
+#
+#  Copyright 2021 The FATE Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+
+import json
+import kfserving
+import os
+import subprocess
+import tempfile
+import torch
+
+from .base import KFServingDeployer
+
+CONFIG_FILE_DIR = "config"
+CONFIG_FILE_NAME = "config.properties"
+CONFIG_FILE = CONFIG_FILE_DIR + "/" + CONFIG_FILE_NAME
+
+MODEL_STORE_DIR = "model-store"
+
+_ts_config = '''inference_address=http://0.0.0.0:8085
+management_address=http://0.0.0.0:8081
+metrics_address=http://0.0.0.0:8082
+enable_metrics_api=true
+metrics_format=prometheus
+number_of_netty_threads=4
+job_queue_size=10
+service_envelope=kfserving
+model_store=/mnt/models/model-store
+model_snapshot={}'''
+
+
+def generate_files(working_dir,
+                   model_name,
+                   torch_model,
+                   handler="",
+                   min_workers=1,
+                   max_workers=5,
+                   batch_size=1,
+                   max_batch_delay=5000,
+                   response_timeout=120):
+    """generate mar file and config file
+
+    The defaults are chosen from
+    https://github.com/kubeflow/kfserving/blob/v0.5.1/docs/samples/v1beta1/torchserve/config.properties
+    """
+    torch_script = torch.jit.script(torch_model)
+    torch_script_file = os.path.join(working_dir, model_name + ".pt")
+    torch_script.save(torch_script_file)
+    if not handler:
+        handler = os.path.join(os.path.dirname(os.path.abspath(__file__)), "_dummy_base_handler.py")
+
+    # there is no official support of using the model-archiver package via python function calls
+    command = ["torch-model-archiver",
+               "--serialized-file",
+               torch_script_file,
+               "--model-name",
+               model_name,
+               "--export-path",
+               working_dir,
+               "--handler",
+               handler,
+               "-v",
+               "1.0",
+               "-f"]
+    ret = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    if ret.returncode != 0:
+        raise RuntimeError("error running torch-model-archiver: {}, command output: {}".format(ret.args, ret.stdout))
+    mar_file = os.path.join(working_dir, model_name + ".mar")
+
+    model_snapshot_dict = {
+        "name": "startup.cfg",
+        "modelCount": 1,
+        "models": {
+            model_name: {
+                "1.0": {
+                    "defaultVersion": True,
+                    "marName": os.path.basename(mar_file),
+                    "minWorkers": min_workers,
+                    "maxWorkers": max_workers,
+                    "batchSize": batch_size,
+                    "maxBatchDelay": max_batch_delay,
+                    "responseTimeout": response_timeout
+                }
+            }
+        }
+    }
+    config = _ts_config.format(json.dumps(model_snapshot_dict))
+    config_file = os.path.join(working_dir, CONFIG_FILE_NAME)
+    with open(config_file, "w") as f:
+        f.write(config)
+
+    return mar_file, config_file
+
+
+class TorchServeKFDeployer(KFServingDeployer):
+    def _do_prepare_model(self):
+        working_dir = tempfile.mkdtemp()
+        mar_file, config_file = generate_files(working_dir,
+                                               self.service_id,
+                                               self.model_object)
+        objects = [{"dest": CONFIG_FILE, "obj": config_file},
+                   {"dest": MODEL_STORE_DIR + "/" + os.path.basename(mar_file), "obj": mar_file}]
+        return objects
+
+    def _do_prepare_predictor(self):
+        self.isvc.spec.predictor.pytorch = kfserving.V1beta1TorchServeSpec(storage_uri=self.storage_uri)

--- a/python/fate_flow/pipelined_model/homo_model_deployer/kfserving/sklearn.py
+++ b/python/fate_flow/pipelined_model/homo_model_deployer/kfserving/sklearn.py
@@ -1,0 +1,47 @@
+#
+#  Copyright 2021 The FATE Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+
+import os
+import tempfile
+from abc import ABC
+
+import joblib
+import kfserving
+
+from .base import KFServingDeployer
+
+
+class SKLearnKFDeployer(KFServingDeployer, ABC):
+    def _do_prepare_model(self):
+        working_dir = tempfile.mkdtemp()
+        local_file = os.path.join(working_dir, "model.joblib")
+        joblib.dump(self.model_object, local_file)
+        return local_file
+
+
+class SKLearnV1KFDeployer(SKLearnKFDeployer):
+    def _do_prepare_predictor(self):
+        self.isvc.spec.predictor.sklearn = kfserving.V1beta1SKLearnSpec(
+            protocol_version='v1',
+            storage_uri=self.storage_uri)
+
+
+class SKLearnV2KFDeployer(SKLearnKFDeployer):
+    def _do_prepare_predictor(self):
+        self.isvc.spec.predictor.sklearn = kfserving.V1beta1SKLearnSpec(
+            protocol_version='v2',
+            storage_uri=self.storage_uri)

--- a/python/fate_flow/pipelined_model/homo_model_deployer/kfserving/tensorflow.py
+++ b/python/fate_flow/pipelined_model/homo_model_deployer/kfserving/tensorflow.py
@@ -1,0 +1,35 @@
+#
+#  Copyright 2021 The FATE Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+
+import kfserving
+import os
+import tempfile
+import tensorflow
+
+from .base import KFServingDeployer
+
+
+class TFServingKFDeployer(KFServingDeployer):
+    def _do_prepare_model(self):
+        working_dir = tempfile.mkdtemp()
+        # TFServing expects an "version string" like 0001 in the model base path
+        local_folder = os.path.join(working_dir, '0001')
+        tensorflow.saved_model.save(self.model_object, local_folder)
+        return working_dir
+
+    def _do_prepare_predictor(self):
+        self.isvc.spec.predictor.tensorflow = kfserving.V1beta1TFServingSpec(storage_uri=self.storage_uri)

--- a/python/fate_flow/pipelined_model/homo_model_deployer/model_deploy.py
+++ b/python/fate_flow/pipelined_model/homo_model_deployer/model_deploy.py
@@ -1,0 +1,51 @@
+#
+#  Copyright 2021 The FATE Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+
+from .kfserving import get_kfserving_deployer
+
+
+def model_deploy(party_model_id,
+                 model_version,
+                 model_object,
+                 framework_name,
+                 service_id,
+                 deployment_type,
+                 deployment_parameters):
+    """
+    Deploy a horizontally-trained model to a target serving system.
+
+    Currently only KFServing is supported
+
+    :param party_model_id: model id with party info to identify the model
+    :param model_version: model version
+    :param model_object: the converted model object
+    :param framework_name: the ML framework of the converted model
+    :param service_id: service name identifier
+    :param deployment_type: currently only "kfserving" is supported
+    :param deployment_parameters: parameters specific to the serving system
+    :return: the deployed service representation, defined by the serving system.
+    """
+    if deployment_type == "kfserving":
+        deployer = get_kfserving_deployer(party_model_id,
+                                          model_version,
+                                          model_object,
+                                          framework_name,
+                                          service_id,
+                                          **deployment_parameters)
+    else:
+        raise ValueError("unknown deployment_type type: {}".format(deployment_type))
+    return deployer.deploy()

--- a/python/fate_flow/pipelined_model/publish_model.py
+++ b/python/fate_flow/pipelined_model/publish_model.py
@@ -18,13 +18,16 @@ import os
 from ruamel import yaml
 
 from fate_flow.settings import IP, HTTP_PORT, FATE_FLOW_MODEL_TRANSFER_ENDPOINT
+from fate_arch.common.base_utils import json_loads
 from fate_arch.common.conf_utils import get_base_config
 from fate_arch.protobuf.python import model_service_pb2
 from fate_arch.protobuf.python import model_service_pb2_grpc
 from fate_flow.settings import stat_logger
 from fate_flow.utils import model_utils
 from fate_flow.pipelined_model import pipelined_model
-from federatedml.protobuf.homo_model_convert.homo_model_convert import model_convert, save_converted_model
+from fate_flow.pipelined_model.homo_model_deployer.model_deploy import model_deploy
+from federatedml.protobuf.homo_model_convert.homo_model_convert import \
+    model_convert, save_converted_model, load_converted_model, get_default_target_framework
 
 
 def generate_publish_model_info(config_data):
@@ -150,7 +153,59 @@ def convert_homo_model(request_data):
     if len(detail) > 0:
         return (0,
                 f"Conversion of homogeneous federated learning component(s) in model "
-                f"{party_model_id}:{model_version} completed. Use export to download the converted model.",
+                f"{party_model_id}:{model_version} completed. Use export or homo/deploy "
+                f"to download or deploy the converted model.",
                 detail)
     else:
         return 100, f"No component in model {party_model_id}:{model_version} can be converted.", None
+
+
+def deploy_homo_model(request_data):
+    party_model_id = model_utils.gen_party_model_id(model_id=request_data["model_id"],
+                                                    role=request_data["role"],
+                                                    party_id=request_data["party_id"])
+    model_version = request_data["model_version"]
+    component_name = request_data['component_name']
+    service_id = request_data['service_id']
+    framework_name = request_data.get('framework_name')
+    model = pipelined_model.PipelinedModel(model_id=party_model_id, model_version=model_version)
+    if not model.exists():
+        return 100, 'Model {} {} does not exist'.format(party_model_id, model_version), None
+
+    # get the model alias from the dsl saved with the pipeline
+    pipeline = model.read_component_model('pipeline', 'pipeline')['Pipeline']
+    train_dsl = json_loads(pipeline.train_dsl)
+    if component_name not in train_dsl.get('components', {}):
+        return 100, 'Model {} {} does not contain component {}'.\
+            format(party_model_id, model_version, component_name), None
+
+    model_alias_list = train_dsl['components'][component_name].get('output', {}).get('model')
+    if not model_alias_list:
+        return 100, 'Component {} in Model {} {} does not have output model'. \
+            format(component_name, party_model_id, model_version), None
+
+    # currently there is only one model output
+    model_alias = model_alias_list[0]
+    converted_model_dir = os.path.join(model.variables_data_path, component_name, model_alias, "converted_model")
+    if not os.path.isdir(converted_model_dir):
+        return 100, '''Component {} in Model {} {} isn't converted'''.\
+            format(component_name, party_model_id, model_version), None
+
+    if not framework_name:
+        module_name = train_dsl['components'][component_name].get('module')
+        buffer_obj = model.read_component_model(component_name, model_alias)
+        framework_name = get_default_target_framework(model_contents=buffer_obj, module_name=module_name)
+
+    model_object = load_converted_model(base_dir=converted_model_dir,
+                                        framework_name=framework_name)
+    deployed_service = model_deploy(party_model_id,
+                                    model_version,
+                                    model_object,
+                                    framework_name,
+                                    service_id,
+                                    request_data['deployment_type'],
+                                    request_data['deployment_parameters'])
+    return (0,
+            f"An online serving service is started in the {request_data['deployment_type']} system.",
+            deployed_service)
+

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -7,7 +7,10 @@ Flask==1.0.2
 gmpy2==2.0.8
 joblib==1.0.1
 kazoo==2.6.1
+kfserving>=0.5.1
+kubernetes>=12.0.1
 lmdb==0.98
+minio>=6.0.2
 numpy>=1.18.4
 peewee==3.9.3
 psutil>=5.7.0
@@ -22,6 +25,7 @@ scikit-learn==0.19.2
 scipy==1.1.0
 tensorflow>=2.4.1
 torch==1.4.0
+torch-model-archiver==0.3.1
 torchvision==0.5.0
 Werkzeug==0.15.3
 coverage==4.5.2

--- a/python/setup.py
+++ b/python/setup.py
@@ -219,8 +219,11 @@ install_requires = \
  'gmpy2==2.0.8',
  'joblib==1.0.1',
  'kazoo==2.6.1',
+ 'kfserving>=0.5.1'
+ 'kubernetes>=12.0.1'
  'lmdb==0.94',
  'numpy==1.18.4',
+ 'minio>=6.0.2',
  'pandas==0.23.4',
  'peewee==3.9.3',
  'psutil==5.6.6',
@@ -234,6 +237,7 @@ install_requires = \
  'scipy==1.1.0',
  'tensorflow==1.15.4',
  'torch==1.4.0',
+ 'torch-model-archiver==0.3.1'
  'torchvision==0.5.0',
  'werkzeug==0.15.3']
 


### PR DESCRIPTION
Changes:
1. Add a "model/homo/deploy" rest api in fate_flow.
2. Implement a deployer of type KFServing, using a separate MinIO service as model storage.
    
After the change, users can create a KFServing InferenceService with this newly added API.
    
