### PR TITLE
Improve the Implement of Pulsar Federation Engine

### DIFF
--- a/conf/service_conf.yaml
+++ b/conf/service_conf.yaml
@@ -63,6 +63,9 @@ fate_on_spark:
     host: 192.168.0.5
     port: 6650
     mng_port: 8080
+    cluster: standalone
+    # all parties should use a same tenant
+    tenant: fl-tenant
     # message ttl in minutes
     topic_ttl: 5
     # default conf/pulsar_route_table.yaml

--- a/docker-build/build_cluster_docker.sh
+++ b/docker-build/build_cluster_docker.sh
@@ -168,7 +168,11 @@ buildModule() {
 
         cd ${SOURCE_DIR}
 
+        [ -f ${SOURCE_DIR}/docker-build/docker/modules/python-nn/requirements.txt ] && rm ${SOURCE_DIR}/docker-build/docker/modules/python-nn/requirements.txt
+        ln ${SOURCE_DIR}/python/requirements.txt ${SOURCE_DIR}/docker-build/docker/modules/python-nn/requirements.txt
         for module in "python" "fateboard" "eggroll" "python-nn"; do
+        echo "START BUILDING BASE IMAGE"
+        cd ${WORKING_DIR}
                 echo "### START BUILDING ${module} ###"
                 docker build --build-arg version=${version} --build-arg fateboard_version=${fateboard_version} --build-arg PREFIX=${PREFIX} --build-arg BASE_TAG=${BASE_TAG} --no-cache -t ${PREFIX}/${module}:${TAG} -f ${SOURCE_DIR}/docker-build/docker/modules/${module}/Dockerfile ${SOURCE_DIR}/docker-build/docker/modules/${module}
                 echo "### FINISH BUILDING ${module} ###"

--- a/docker-build/docker/base/Dockerfile
+++ b/docker-build/docker/base/Dockerfile
@@ -17,7 +17,8 @@ RUN set -eux && \
     yum clean all
 
 RUN pip install --upgrade pip && \
-    sed -i '/tensorflow==1.15.4/d' /data/projects/python/requirements.txt && \
+    sed -i '/tensorflow>=2.4.1/d' /data/projects/python/requirements.txt && \
     sed -i '/torch==1.4.0/d' /data/projects/python/requirements.txt && \
     sed -i '/torchvision==0.5.0/d' /data/projects/python/requirements.txt && \
+    sed -i '/pytorch-lightning>=1.2.1/d' /data/projects/python/requirements.txt && \
     pip install -r requirements.txt

--- a/docker-build/docker/modules/python-nn/Dockerfile
+++ b/docker-build/docker/modules/python-nn/Dockerfile
@@ -3,4 +3,5 @@ ARG PREFIX=prefix
 ARG BASE_TAG=tag
 FROM ${PREFIX}/python:${BASE_TAG}
 
-RUN pip install torch==1.4.0 tensorflow>=1.15.4 torchvision==0.5.0
+COPY requirements.txt /data/projects/python/
+RUN pip install -r /data/projects/python/requirements.txt

--- a/python/fate_arch/federation/pulsar/_mq_channel.py
+++ b/python/fate_arch/federation/pulsar/_mq_channel.py
@@ -14,7 +14,7 @@ CHANNEL_TYPE_PRODUCER = 'producer'
 CHANNEL_TYPE_CONSUMER = 'consumer'
 DEFAULT_TENANT = 'fl-tenant'
 DEFAULT_CLUSTER = 'standalone'
-TOPIC_PREFIX = DEFAULT_TENANT + '/{}/{}'
+TOPIC_PREFIX = '{}/{}/{}'
 UNIQUE_PRODUCER_NAME = 'unique_producer'
 UNIQUE_CONSUMER_NAME = 'unique_consumer'
 DEFAULT_SUBSCRIPTION_NAME = 'unique'
@@ -34,8 +34,7 @@ def connection_retry(func):
                 break
             except Exception as e:
                 LOGGER.debug(e)
-
-                time.sleep(1)
+                time.sleep(3)
         return res
     return wrapper
 
@@ -44,10 +43,12 @@ def connection_retry(func):
 
 class MQChannel(object):
     # TODO add credential to secure pulsar cluster
-    def __init__(self, host, port, pulsar_namespace, pulsar_send_topic, pulsar_receive_topic, party_id, role, credential=None, extra_args: dict = None):
+    def __init__(self, host, port, mng_port, pulsar_tenant, pulsar_namespace, pulsar_send_topic, pulsar_receive_topic, party_id, role, credential=None, extra_args: dict = None):
         # "host:port" is used to connect the pulsar broker
         self._host = host
         self._port = port
+        self._mng_port = mng_port
+        self._tenant = pulsar_tenant
         self._namespace = pulsar_namespace
         self._send_topic = pulsar_send_topic
         self._receive_topic = pulsar_receive_topic
@@ -78,6 +79,7 @@ class MQChannel(object):
     def party_id(self):
         return self._party_id
 
+    # splitting the creation of producer and producer to avoid resource wasted
     @connection_retry
     def basic_publish(self, body, properties):
         self._get_or_create_producer()
@@ -85,8 +87,12 @@ class MQChannel(object):
             self._producer_send.topic()))
         LOGGER.debug('send data size: {}'.format(len(body)))
 
-        self._producer_send.send(content=body, properties=properties)
-        self._sequence_id = self._producer_send.last_sequence_id()
+        message_id = self._producer_send.send(
+            content=body, properties=properties)
+        if message_id is None:
+            raise Exception("publish failed")
+
+        self._sequence_id = message_id
 
     @connection_retry
     def consume(self):
@@ -109,13 +115,17 @@ class MQChannel(object):
             self._consumer_receive.negative_acknowledge(message)
 
     def cancel(self):
-        # self._get_or_create_consumer()
-        # self._get_or_create_producer()
-        try:
-            self._consumer_conn.close()
-            self._producer_conn.close()
-        except Exception as e:
-            LOGGER.debug('meet {} when trying to close client'.format(e))
+        if self._consumer_conn is not None:
+            try:
+                self._consumer_conn.close()
+            except Exception as e:
+                LOGGER.debug('meet {} when trying to close consumer'.format(e))
+
+        if self._producer_conn is not None:
+            try:
+                self._producer_conn.close()
+            except Exception as e:
+                LOGGER.debug('meet {} when trying to close producer'.format(e))
 
     @connection_retry
     def _get_or_create_producer(self):
@@ -131,10 +141,12 @@ class MQChannel(object):
 
             # alway used current client to fetch producer
             try:
-                self._producer_send = self._producer_conn.create_producer(TOPIC_PREFIX.format(self._namespace, self._send_topic),
+                self._producer_send = self._producer_conn.create_producer(TOPIC_PREFIX.format(self._tenant, self._namespace, self._send_topic),
                                                                           producer_name=UNIQUE_PRODUCER_NAME,
-                                                                          send_timeout_millis=50000,
-                                                                          initial_sequence_id=self._sequence_id,
+                                                                          send_timeout_millis=500,
+                                                                          max_pending_messages=500,
+                                                                          compression_type=pulsar.CompressionType.LZ4,
+                                                                          # initial_sequence_id=self._sequence_id,
                                                                           **self._producer_config)
             except Exception:
                 self._producer_conn = None
@@ -152,15 +164,19 @@ class MQChannel(object):
                 self._consumer_conn = None
 
             try:
-                self._consumer_receive = self._consumer_conn.subscribe(TOPIC_PREFIX.format(self._namespace, self._receive_topic),
+                self._consumer_receive = self._consumer_conn.subscribe(TOPIC_PREFIX.format(self._tenant, self._namespace, self._receive_topic),
                                                                        subscription_name=DEFAULT_SUBSCRIPTION_NAME,
                                                                        consumer_name=UNIQUE_CONSUMER_NAME,
-                                                                       initial_position=_pulsar.InitialPosition.Earliest,
+                                                                       initial_position=pulsar.InitialPosition.Earliest,
+                                                                       replicate_subscription_state_enabled=True,
                                                                        **self._consumer_config)
             except Exception:
                 self._consumer_conn = None
 
     def _check_producer_alive(self):
+        if self._producer_conn is None or self._producer_send is None:
+            return False
+
         try:
             self._producer_conn.get_topic_partitions("test-alive")
             self._producer_send.flush()
@@ -178,6 +194,9 @@ class MQChannel(object):
             return False
 
     def _check_consumer_alive(self):
+        if self._consumer_conn is None or self._consumer_receive is None:
+            return False
+
         try:
             self._consumer_conn.get_topic_partitions("test-alive")
             #message = self._consumer_receive.receive(timeout_millis=3000)

--- a/python/fate_arch/federation/pulsar/_pulsar_manager.py
+++ b/python/fate_arch/federation/pulsar/_pulsar_manager.py
@@ -10,6 +10,7 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 from fate_arch.common.log import getLogger
+from fate_arch.federation.pulsar._mq_channel import DEFAULT_SUBSCRIPTION_NAME
 
 logger = getLogger()
 
@@ -199,4 +200,45 @@ class PulsarManager():
             self.service_url + 'namespaces/{}/{}/messageTTL'.format(tenant, namespace), json=mintues*60
         )
 
+        return response
+
+    def unsubscribe_namespace_all_topics(self, tenant: str, namespace: str, subscription_name: str):
+        session = self._create_session()
+        response = session.post(
+            self.service_url +
+            'namespaces/{}/{}/unsubscribe/{}'.format(
+                tenant, namespace, subscription_name)
+        )
+        return response
+
+    def set_retention(self, tenant: str, namespace: str,
+                      retention_time_in_minutes: int = 0, retention_size_in_MB: int = 0):
+        session = self._create_session()
+
+        data = {'retentionTimeInMinutes': retention_time_in_minutes,
+                'retentionSizeInMB': retention_size_in_MB}
+
+        response = session.post(
+            self.service_url +
+            'namespaces/{}/{}/retention'.format(tenant, namespace), data=json.dumps(data)
+        )
+        return response
+
+    def remove_retention(self, tenant: str, namespace: str):
+        session = self._create_session()
+        response = session.delete(
+            self.service_url +
+            'namespaces/{}/{}/retention'.format(tenant, namespace),
+        )
+
+        return response
+
+    # topic
+    def unsubscribe_topic(self, tenant: str, namespace: str, topic: str, subscription_name: str):
+        session = self._create_session()
+        response = session.delete(
+            self.service_url +
+            'persistent/{}/{}/{}/subscription/{}'.format(
+                tenant, namespace, topic, subscription_name)
+        )
         return response

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -30,8 +30,9 @@ cryptography==3.2.1
 libsm3py==0.0.1
 sortedcontainers==2.2.2
 pytorch-lightning>=1.2.1
-pulsar-client==2.7.0
 filelock==3.0.12
+pulsar-client==2.8.0
+fastavro==1.4.1
 
 # addtional requirements for eggroll
 grpcio>=1.24.3


### PR DESCRIPTION
1. Update docker build
2. Support using specified pulsar cluster and tenant
    - add 'cluster' and 'tenant' to pulsar field of fateflow's config
    - it is necessary to unify tenant name between different parties
3. Optimize the unsubscribtion mechanism
    - move set ttl to namespaces' creation
    - unsubscribe once job was finished
4. Update Pulsar Usage
    - enable subscription-replicate feature
    - enable retention to keep topic alive without subscription
   - improve the check alive in connection
5. Improve the cleanup process of Pulsar namespace
    - remove all subscription
    - remove all retention policy
    - remove all remote cluster

fastavro is required, which can be referred to https://pulsar.apache.org/docs/fr/client-libraries-python/#optional-dependencies
Signed-off-by: jiahaoc <jiahaoc@vmware.com>

