### PR TITLE
👷 Add github action for PyPI release

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,94 @@
+# use pypi/<version>/develop to test build and publish to pypitest
+# use pypi/<version>/release to publish pypi
+
+name: build-wheel
+
+on:
+  push:
+    branches:
+      - 'pypi/**/develop'
+      - 'pypi/**/release'
+
+jobs:
+  build:
+    name: Build fate client and fate_test
+    strategy:
+      fail-fast: true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Extract version and name
+        shell: bash
+        run: |
+          # extract version and name from patterm: pypi/<version>/<name>
+          echo ::set-output name=version::$(echo ${GITHUB_REF} | sed -E -e 's/refs\/heads\/pypi\/(.*)\/(develop|release)/\1/g')
+          echo ::set-output name=name::$(echo ${GITHUB_REF} | sed -E -e 's/refs\/heads\/pypi\/(.*)\/(develop|release)/\2/g')
+        id: extract
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+
+      - name: Prepare poetry
+        uses: abatilo/actions-poetry@v2.0.0
+        with:
+          poetry-version: 1.1.6
+
+      - name: Build fate_client
+        run: |
+          cd python/fate_client
+          rm -f setup.py
+          # clear README.rst
+          echo "# fate client" > README.rst
+          # bump fate client version
+          poetry version ${{steps.extract.outputs.version}}
+          # build package, saved in dist/
+          poetry build
+
+      - name: Build fate_test
+        run: |
+          cd python/fate_test &&
+          # clear README.rst
+          echo "# fate test" > README.rst
+          # bump fate test version
+          poetry version ${{steps.extract.outputs.version}}
+          # update dependency version
+          sed -E -i "s/(fate_client\s*=\s*)(.*)/\1\"${{steps.extract.outputs.version}}\"/g" pyproject.toml
+          cat pyproject.toml
+          # build package, saved in dist/
+          poetry build
+
+      - name: List dist files
+        run: ls -lh python/fate_client/dist/ python/fate_test/dist/
+
+      - name: Twine check
+        run: |
+          pip install -U twine
+          twine check python/fate_client/dist/*
+          twine check python/fate_test/dist/*
+
+      - name: Upload to artifact
+        uses: actions/upload-artifact@v2
+        with:
+          path: |
+            python/fate_client/dist/*
+            python/fate_test/dist/*
+
+      - name: Upload to PyPI Test
+        if: ${{ steps.extract.outputs.name == 'develop' }}
+        run: |
+          twine upload --repository testpypi python/fate_client/dist/*
+          twine upload --repository testpypi python/fate_test/dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.pypitest_token }}
+
+      - name: Upload to PyPI
+        if: ${{ steps.extract.outputs.name == 'release' }}
+        run: |
+          twine upload --repository testpypi python/fate_client/dist/*
+          twine upload --repository testpypi python/fate_test/dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.pypi_token }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -87,8 +87,8 @@ jobs:
       - name: Upload to PyPI
         if: ${{ steps.extract.outputs.name == 'release' }}
         run: |
-          twine upload --repository testpypi python/fate_client/dist/*
-          twine upload --repository testpypi python/fate_test/dist/*
+          twine upload python/fate_client/dist/*
+          twine upload python/fate_test/dist/*
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.pypi_token }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -75,6 +75,12 @@ jobs:
             python/fate_client/dist/*
             python/fate_test/dist/*
 
+      - name: Test Install
+        run: |
+          pip install -U pip
+          pip install python/fate_client/dist/fate_client-${{steps.extract.outputs.version}}.tar.gz
+          pip install python/fate_test/dist/fate_test-${{steps.extract.outputs.version}}.tar.gz
+
       - name: Upload to PyPI Test
         if: ${{ steps.extract.outputs.name == 'develop' }}
         run: |


### PR DESCRIPTION

Changes:

1. Add github action to release package to PyPI

## Rules
1. use branch named pypi/<version>/develop to trigger package release to pypitest for test
2. use branch named pypi/<version>/release to trigger package release to pypi for product

Please double check before release a package since re-upload to PyPI with same package version is not allowed!
