### PR TITLE
perf(data_split): change filter function to join

### DIFF
--- a/python/federatedml/model_selection/data_split/data_split.py
+++ b/python/federatedml/model_selection/data_split/data_split.py
@@ -18,6 +18,7 @@ import collections
 
 from sklearn.model_selection import train_test_split
 
+from fate_arch.session import computing_session
 from fate_flow.entity.metric import Metric, MetricMeta
 from federatedml.feature.binning.base_binning import BaseBinning
 from federatedml.model_base import ModelBase
@@ -289,7 +290,8 @@ class DataSplitter(ModelBase):
 
     @staticmethod
     def _match_id(data_inst, ids):
-        return data_inst.filter(lambda k, v: k in ids)
+        id_table = computing_session.parallelize(ids, include_key=False, partition=data_inst.partitions)
+        return data_inst.join(id_table.map(lambda k, v: (v, 1)), lambda v1, v2: v1)
 
     @staticmethod
     def _set_output_table_schema(data_inst, schema):


### PR DESCRIPTION
Changes:

1. Change filter function to join function in data_split component.


By changing filter to join function, data_split component running time can be extremely optimized. For example, when dealing with a dataset with 3,000,000 elements, the cost decrease from 20,000 seconds to almost 200 seconds in my environment.