### PR TITLE
加密后的loss值变量命名重新定义，与代码上下文中加密后变量名风格保持一致

### DIFF
--- a/python/federatedml/optim/gradient/hetero_lr_gradient_and_loss.py
+++ b/python/federatedml/optim/gradient/hetero_lr_gradient_and_loss.py
@@ -170,8 +170,8 @@ class Host(hetero_linear_model_gradient.Host, loss_sync.Host):
 
         loss_regular = optimizer.loss_norm(lr_weights)
         if loss_regular is not None:
-            loss_regular = cipher_operator.encrypt(loss_regular)
-            self.remote_loss_regular(loss_regular, suffix=current_suffix)
+            en_loss_regular = cipher_operator.encrypt(loss_regular)
+            self.remote_loss_regular(en_loss_regular, suffix=current_suffix)
 
 
 class Arbiter(hetero_linear_model_gradient.Arbiter, loss_sync.Arbiter):


### PR DESCRIPTION
Fixes  ISSUE #xxx
nothing

Changes:
1. location：python/federatedml/optim/gradient/hetero_lr_gradient_and_loss.py --- 加密后的loss值变量命名重新定义，与代码上下文中加密后变量名风格保持一致




