### PR TITLE
fix #3143 make the en doc more clear

### DIFF
--- a/standalone-deploy/README.md
+++ b/standalone-deploy/README.md
@@ -75,7 +75,7 @@ bash install_standalone_docker.sh
 
    To conveniently interact with FATE, we provide tools [FATE-Client](../python/fate_client) and [FATE-Test](../python/fate_test).
 
-   Install FATE-Client and FATE-Test with the following commands:
+   Install FATE-Client and FATE-Test with the following commands in the container:
 
    ```
     pip install fate-client


### PR DESCRIPTION
Fixes  ISSUE #3143 

Changes:

1. Clarify the commands should be executed in the container instead of in the host. The [Chinese version](https://github.com/FederatedAI/FATE/blob/master/standalone-deploy/doc/Fate-standalone_deployment_guide_zh.md#1-%E4%BD%BF%E7%94%A8docker%E9%95%9C%E5%83%8F%E5%AE%89%E8%A3%85fate%E6%8E%A8%E8%8D%90) does mentioned it (although it's ambiguous as well IMHO. `环境内` can mean anything, e.g. a python virtual env, `容器内` will be more clear) while the English version completely missed it. 
