### PR TITLE
add `__rmul__` and `__radd__` in weights

### DIFF
--- a/python/federatedml/framework/weights.py
+++ b/python/federatedml/framework/weights.py
@@ -88,6 +88,9 @@ class Weights(metaclass=segment_transfer_enabled()):
 
     def __mul__(self, other):
         return self.map_values(lambda x: x * other, inplace=False)
+    
+    def __rmul__(self, other):
+        return self * other
 
     def __iadd__(self, other):
         return self.binary_op(other, operator.add, inplace=True)
@@ -95,6 +98,9 @@ class Weights(metaclass=segment_transfer_enabled()):
     def __add__(self, other):
         LOGGER.debug("In binary_op0, _w: {}".format(self._weights))
         return self.binary_op(other, operator.add, inplace=False)
+    
+    def __radd__(self, other):
+        return self + other
 
     def __isub__(self, other):
         return self.binary_op(other, operator.sub, inplace=True)


### PR DESCRIPTION
Signed-off-by: gxcuit gxcuit@163.com

Fixes  ISSUE #3475

Changes:

1. Add `__rmul__` and `__radd__` to support reflected (swapped) operands.



