### PR TITLE
add github action to close stale issue

### DIFF
--- a/.github/workflows/autopep8-command.yml
+++ b/.github/workflows/autopep8-command.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           git config --global user.name 'actions-bot'
           git config --global user.email '58130806+actions-bot@users.noreply.github.com'
-          git commit -am "[autopep8-command] fixes"
+          git commit -am "[autopep8-command] fixes" -s
           git push
 
       - name: Add reaction

--- a/.github/workflows/close-state-issue.yml
+++ b/.github/workflows/close-state-issue.yml
@@ -1,0 +1,24 @@
+name: 'Close stale issues'
+on:
+  schedule:
+    - cron: '30 9 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          repo-token: ${{ secrets.PAT }}
+          stale-issue-label: stale
+          stale-issue-message: >
+            Looks like this issue hasn't been updated in a while so we're going to go ahead and mark this as `Stale`. <br>
+            Feel free to remove the `Stale` label if you feel this was a mistake. <br>
+            If you are unable to remove the `Stale` label please contact a maintainer in order to do so. <br>
+            `Stale` issue will automatically be closed 5 days after being marked `Stale` <br>
+          stale-pr-message: 'This PR is stale because it has been open 30 days with no activity.'
+          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity. Feel free to reopen if this issue not be resoloved.'
+          days-before-stale: 30
+          days-before-close: 5
+          days-before-pr-close: -1


### PR DESCRIPTION
Signed-off-by: weiwee <wbwmat@gmail.com>

Changes:

1. add GitHub Action to stale and close issue

2. issue with no response for 30 days will be marks as stale

3. issue labeled `stale` will be close after 5 days

4. fix signoff for github-action-bot

