### PR TITLE
table add copy api

### DIFF
--- a/python/fate_arch/abc/_computing.py
+++ b/python/fate_arch/abc/_computing.py
@@ -61,6 +61,10 @@ class CTableABC(metaclass=ABCMeta):
         """
         ...
 
+   @abc.abstractmethod
+   def copy(self):
+      ...
+
     @abc.abstractmethod
     def save(self, address: AddressABC, partitions: int, schema: dict, **kwargs):
         """

--- a/python/fate_arch/computing/eggroll/_table.py
+++ b/python/fate_arch/computing/eggroll/_table.py
@@ -41,6 +41,9 @@ class Table(CTableABC):
     def partitions(self):
         return self._rp.get_partitions()
 
+    def copy(self):
+        return Table(self._rp.map_values(lambda x: x))
+
     @computing_profile
     def save(self, address, partitions, schema: dict, **kwargs):
         options = kwargs.get("options", {})

--- a/python/fate_arch/computing/spark/_table.py
+++ b/python/fate_arch/computing/spark/_table.py
@@ -53,6 +53,10 @@ class Table(CTableABC):
         except BaseException:
             return
 
+    def copy(self):
+        """rdd is immutable, yet, inside content could be modify in some case"""
+        return Table(_map_value(self._rdd, lambda x: x))
+
     @computing_profile
     def save(self, address, partitions, schema, **kwargs):
         from fate_arch.common.address import HDFSAddress

--- a/python/fate_arch/computing/standalone/_table.py
+++ b/python/fate_arch/computing/standalone/_table.py
@@ -43,6 +43,9 @@ class Table(CTableABC):
     def partitions(self):
         return self._table.partitions
 
+    def copy(self):
+        return Table(self._table.mapValues())
+
     @computing_profile
     def save(self, address, partitions, schema, **kwargs):
         from fate_arch.common.address import StandaloneAddress


### PR DESCRIPTION
We need copy a table in some case with `mapValues`, which is a bit odd. It's better idea for `Table` to add a build-in one.