### PR TITLE
model_loader bug fix

### DIFF
--- a/python/federatedml/components/components.py
+++ b/python/federatedml/components/components.py
@@ -24,6 +24,7 @@ from federatedml.model_base import ModelBase
 from federatedml.param.base_param import BaseParam
 from federatedml.util import LOGGER
 
+_ml_base = Path(__file__).resolve().parent.parent.parent
 
 class _RunnerDecorator:
     def __init__(self, meta) -> None:
@@ -186,9 +187,16 @@ class Components:
     def get(cls, name: str, cache) -> ComponentMeta:
         if cache:
             importlib.import_module(cache[name]["module"])
+
         else:
-            for p in cls._components_base().glob("**/*.py"):
-                module_name = _get_module_name_by_path(p, cls._module_base())
+            _components_base = Path(__file__).resolve().parent
+            for p in _components_base.glob("**/*.py"):
+                module_name = '.'.join(
+                    p.absolute()
+                    .relative_to(_ml_base)
+                    .with_suffix("")
+                    .parts
+                )
                 importlib.import_module(module_name)
 
         return ComponentMeta.get_meta(name)


### PR DESCRIPTION
整个编排作业包含了model_loader组件，且model_loader组件加载了诸如hetero_feature_binning等不能在arbiter节点运行的组件，同时整个编排作业需要在arbiter组件上执行场景下，model_loadr组件在arbiter节点上会有找不到组件模型的异常抛出，导致model_loader组件运行失败
这个问题需要配合这个pr中对于model_loader.py文件的修改一起提交：https://github.com/FederatedAI/FATE-Flow/pull/200/

Signed-off-by: githubID email

Fixes  ISSUE #xxx

Changes:

1.

2.

3.


