### PR TITLE
Fix #3526, fix  standalone deployment when using the compiled installer

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -1,5 +1,5 @@
-RELEASE_VERSION_TAG_NAME="release"
 shopt -s expand_aliases
+RELEASE_VERSION_TAG_NAME="release"
 kernel=$(uname -s)
 echo "[INFO] kernel: ${kernel}"
 case "${kernel}" in

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -1,5 +1,5 @@
 RELEASE_VERSION_TAG_NAME="release"
-
+shopt -s expand_aliases
 kernel=$(uname -s)
 echo "[INFO] kernel: ${kernel}"
 case "${kernel}" in


### PR DESCRIPTION
Signed-off-by: gxcuit <gxcuit@163.com>

Fixes  ISSUE #3526 

Changes:

1. add `shopt -s expand_aliases` in bin/common.sh


When deploying FATE in ubuntu using the compiled installer, it will incur a `fate_sed_cmd: command not found error. It is because 

> Aliases are not expanded when the shell is not interactive, unless the expand_aliases shell option is set using shopt


Please kindly refer to #3526 and [https://stackoverflow.com/questions/24054154/how-do-create-an-alias-in-shell-scripts](stackoverflow)

