### PR TITLE
@abc.abstractclassmethod已废弃停用，更新为@abc.abstractmethod

### DIFF
--- a/python/federatedml/framework/hetero/sync/gradient_sync.py
+++ b/python/federatedml/framework/hetero/sync/gradient_sync.py
@@ -20,11 +20,11 @@ import abc
 
 
 class Guest(object):
-    @abc.abstractclassmethod
+    @abc.abstractmethod
     def compute_intermediate(self, *args, **kwargs):
         raise NotImplementedError("This method should be be called here")
 
-    @abc.abstractclassmethod
+    @abc.abstractmethod
     def aggregate_host_result(self, *args, **kwargs):
         raise NotImplementedError("This method should be be called here")
 
@@ -33,7 +33,7 @@ class Guest(object):
 
 
 class Host(object):
-    @abc.abstractclassmethod
+    @abc.abstractmethod
     def compute_intermediate(self, *args, **kwargs):
         raise NotImplementedError("This method should be be called here")
 


### PR DESCRIPTION
@jat001 @dylan-fan @zhihuiwan 

修改文件：
python/federatedml/framework/hetero/sync/gradient_sync.py

修改内容：
@abc.abstractclassmethod已废弃停用，更新为@abc.abstractmethod