### PR TITLE
Reduce the necessary size of the base and eggroll images

### DIFF
--- a/build/docker-build/docker/base/Dockerfile
+++ b/build/docker-build/docker/base/Dockerfile
@@ -21,4 +21,5 @@ RUN pip install --upgrade pip && \
     sed -i '/torch.*/d' /data/projects/python/requirements.txt && \
     sed -i '/torchvision.*/d' /data/projects/python/requirements.txt && \
     sed -i '/pytorch-lightning.*/d' /data/projects/python/requirements.txt && \
+    sed -i '/pyspark.*/d' /data/projects/python/requirements.txt && \
     pip install -r requirements.txt

--- a/build/docker-build/docker/modules/eggroll/Dockerfile
+++ b/build/docker-build/docker/modules/eggroll/Dockerfile
@@ -17,7 +17,7 @@ FROM ${PREFIX}/base-image:${BASE_TAG}
 RUN set -eux; \
     rpm --rebuilddb; \
     rpm --import /etc/pki/rpm-gpg/RPM*; \
-    yum install -y which strace java-1.8.0-openjdk java-1.8.0-openjdk-devel ; \
+    yum install -y which strace java-1.8.0-openjdk ; \
     yum clean all;
 
 WORKDIR /data/projects/fate/eggroll/


### PR DESCRIPTION
Signed-off-by: Chen Jing <jingch@vmware.com>

Fixes  #3854

## Description

1. The pyspark module is a pretty large one, no need to be installed on the base image stage, because eggroll archetecture do not need this module at all. This can save about 210MB for the compressed size of eggroll and python images.
2. There is no compiling requirement for the eggroll image, so no need to install the java-1.8.0-openjdk module.


## Test (using K8s to deploy FATE)

### Image size
eggroll: 858 MB -> 635 MB
python: 814 MB -> 606 MB

### Functionality

Verified that we can upload data and train a module successfully in 2 modes:
1. eggroll mode
2. spark+rabbitmq mode

![Screen Shot 2022-06-20 at 21 56 02](https://user-images.githubusercontent.com/15973672/174617564-b4964a14-1198-4580-8d2a-0ce28dbb8f09.png)



