### PR TITLE
update pulsar message max size to 1MB

### DIFF
--- a/python/fate_arch/federation/pulsar/_federation.py
+++ b/python/fate_arch/federation/pulsar/_federation.py
@@ -31,8 +31,8 @@ from fate_arch.federation._datastream import Datastream
 
 
 LOGGER = getLogger()
-# default message max size in bytes = 50MB
-DEFAULT_MESSAGE_MAX_SIZE = 104857 * 50
+# default message max size in bytes = 1MB
+DEFAULT_MESSAGE_MAX_SIZE = 1024 * 1024
 NAME_DTYPE_TAG = "<dtype>"
 _SPLIT_ = "^"
 


### PR DESCRIPTION
issue:
- We have did some benchmark, and figure out `DEFAULT_MESSAGE_MAX_SIZE` will affects efficient of intersection.

env:
- fate 1.7.2
- 64c/64g/1tb

plan:
- pipeline: reader -> data transformer -> intercection
- J & N, pulsar message is 5MB
- J1 & N1, pulsar message is 1MB

result:
<img width="1181" alt="image" src="https://user-images.githubusercontent.com/2622666/185039089-74e32fdc-2480-4cf9-9365-33b9b2e7d829.png">

Related issue:
- https://github.com/FederatedAI/KubeFATE/pull/715