### PR TITLE
chore: platform specific syntax for pulsar-client

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,7 +1,6 @@
 pip>=21
 apsw<3.10
 importlib_metadata<2.0.0
-markdown==3.3.5
 pkginfo==1.7.1
 beautifultable==1.0.0
 cachetools==3.0.0
@@ -46,7 +45,8 @@ cryptography==3.3.2
 sortedcontainers==2.2.2
 pytorch-lightning>=1.6.5
 filelock==3.3.1
-pulsar-client==2.10.1
+pulsar-client==2.10.1; sys_platform == "linux"
+pulsar-client==2.10.0; sys_platform == "darwin"
 fastavro==1.4.1
 lightgbm==3.3.1
 etaf-crypto
@@ -70,4 +70,3 @@ prettytable>=1.0.0,<2.0.0
 setuptools>=50.0,<51.0
 sshtunnel>=0.1.5,<0.2.0
 packaging<21.0,>=20.4
-


### PR DESCRIPTION
1. use pulsar-client == 2.10.0 for macos since 2.10.1 for macos not published
2. remove markdown since 3.3.5 is yanked

Signed-off-by: weiwee <wbwmat@gmail.com>
