### PR TITLE
Fix missing "import os" for upload tutorial

### DIFF
--- a/doc/tutorial/pipeline/pipeline_tutorial_upload.ipynb
+++ b/doc/tutorial/pipeline/pipeline_tutorial_upload.ipynb
@@ -171,6 +171,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
+    "\n",
     "data_base = \"/workspace/FATE/\"\n",
     "pipeline_upload.add_upload_data(file=os.path.join(data_base, \"examples/data/breast_hetero_guest.csv\"),\n",
     "                                table_name=dense_data_guest[\"name\"],             # table name\n",


### PR DESCRIPTION
The notebook is missing `os` package import. "Run all cells" would fail due to this.

Signed-off-by: orionHong orionxhr@outlook.com

Changes:

1. Just added `import os` to the notebook.


