### PR TITLE
add venv-pack into requirements for dependence distribution purpose

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -50,6 +50,7 @@ sklearn2pmml==0.84.2
 nyoka==5.3.0
 transformers==4.23.1
 impyla==0.18.0
+venv-pack==0.2.0
 etaf-crypto
 
 # addtional requirements for eggroll


### PR DESCRIPTION
Signed-off-by: Chen Jing <jingch@vmware.com>

The purpose for this pip package is for package the python virtual environment in fateflow.

Reference: https://github.com/FederatedAI/FATE-Flow/pull/352


