### PR TITLE
use bash instead of sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,10 @@ script:
   - tar -xzf standalone_fate_master_1.5.1.tar.gz
   - cd standalone_fate_master_1.5.1
   - sed -i.bak "s/sh  service.sh/bash service.sh/g" init.sh
-  - sh init.sh init
+  - bash init.sh init
   - ls -alh
   - source bin/init_env.sh
   - bash ./python/federatedml/test/run_test.sh
 after_success:
   - conda install -c conda-forge codecov --yes
   - cd ./python/federatedml/test && codecov
-
-

--- a/deploy/cluster-deploy/doc/fate_on_eggroll/fate-allinone_deployment_guide.md
+++ b/deploy/cluster-deploy/doc/fate_on_eggroll/fate-allinone_deployment_guide.md
@@ -198,7 +198,7 @@ echo '/data/swapfile128G swap swap defaults 0 0' >> /etc/fstab
 Or create by using the code package script in Section 5.1, and execute as app user:
 
 ```
-sh /data/projects/fate_cluster_install_${version}_release/tools-install/makeVirtualDisk.sh
+bash /data/projects/fate_cluster_install_${version}_release/tools-install/makeVirtualDisk.sh
 Waring: please make sure has enough space of your disk first!!! (Please make sure there is enough storage space)
 current user has sudo privilege(yes|no):yes      (Whether the user has sudo privilege; enter yes and do not abbreviate it)
 Enter store directory:/data    (Set the storage path for virtual memory files; make sure the directory exists and do not set it to the root directory)
@@ -275,7 +275,7 @@ Copy the check script fate_cluster_install_${version}_release/tools-install/chec
 
 ```
 #Execute the script check on the servers 192.168.0.1 and 192.168.0.2 respectively
-sh ./check.sh
+bash ./check.sh
 
 #Make sure that sudo is configured for app user
 #Virtual memory, minimum 128G in size; otherwise, refer to section 4.6 for resetting
@@ -472,7 +472,7 @@ Modify the corresponding configuration items in the setup.conf file according to
 
 ```
 cd fate_cluster_install_${version}_release/allInone
-nohup sh ./deploy.sh > logs/boot.log 2>&1 &
+nohup bash ./deploy.sh > logs/boot.log 2>&1 &
 ```
 
 The deployment log is located in the fate_cluster_install_${version}_release/allInone/logs directory. A user can check it in real time to see if there are any errors:
@@ -609,7 +609,7 @@ Start/Shutdown/View/Restart mysql service
 
 ```bash
 cd /data/projects/fate/common/mysql/mysql-*
-sh ./service.sh start|stop|status|restart
+bash ./service.sh start|stop|status|restart
 ```
 
 #### 7.1.2. Eggroll Service Management
@@ -622,13 +622,13 @@ cd /data/projects/fate/eggroll
 Start/Shutdown/View/Restart all modules:
 
 ```bash
-sh ./bin/eggroll.sh all start/stop/status/restart
+bash ./bin/eggroll.sh all start/stop/status/restart
 ```
 
 Start/Shutdown/View/Restart a single module (clustermanager, nodemanager, rollsite):
 
 ```bash
-sh ./bin/eggroll.sh clustermanager start/stop/status/restart
+bash ./bin/eggroll.sh clustermanager start/stop/status/restart
 ```
 
 #### 7.1.3. FATE Service Management
@@ -638,7 +638,7 @@ sh ./bin/eggroll.sh clustermanager start/stop/status/restart
 ```bash
 source /data/projects/fate/bin/init_env.sh
 cd /data/projects/fate/fateflow/bin
-sh service.sh start|stop|status|restart
+bash service.sh start|stop|status|restart
 ```
 
 To start the modules on an individual basis, a user must start eggroll before fateflow, as fateflow requires eggroll to run.
@@ -647,7 +647,7 @@ To start the modules on an individual basis, a user must start eggroll before fa
 
 ```bash
 cd /data/projects/fate/fateboard
-sh service.sh start|stop|status|restart
+bash service.sh start|stop|status|restart
 ```
 
 ### 7.2. View Processes and Ports

--- a/deploy/cluster-deploy/doc/fate_on_eggroll/fate-allinone_deployment_guide.zh.md
+++ b/deploy/cluster-deploy/doc/fate_on_eggroll/fate-allinone_deployment_guide.zh.md
@@ -199,7 +199,7 @@ echo '/data/swapfile128G swap swap defaults 0 0' >> /etc/fstab
 或者使用5.1章节的代码包中的脚本创建，app用户执行：
 
 ```
-sh /data/projects/fate_cluster_install_${version}_release/tools-install/makeVirtualDisk.sh
+bash /data/projects/fate_cluster_install_${version}_release/tools-install/makeVirtualDisk.sh
 Waring: please make sure has enough space of your disk first!!! （请确认有足够的存储空间）
 current user has sudo privilege(yes|no):yes      （是否有sudo权限，输入yes，不能简写）
 Enter store directory:/data    （设置虚拟内存文件的存放路径，确保目录存在和不要设置在根目录）
@@ -277,7 +277,7 @@ tar xzf fate_cluster_install_${version}_release.tar.gz
 
 ```
 #在192.168.0.1和192.168.0.2服务器上分别执行检查脚本
-sh ./check.sh
+bash ./check.sh
 
 #确认app用户已配置sudo
 #虚拟内存，size不低于128G，如不满足需参考4.6章节重新设置
@@ -474,7 +474,7 @@ nodemanager_port=4671
 
 ```
 cd fate_cluster_install_${version}_release/allInone
-nohup sh ./deploy.sh > logs/boot.log 2>&1 &
+nohup bash ./deploy.sh > logs/boot.log 2>&1 &
 ```
 
 部署日志输出在fate_cluster_install_${version}_release/allInone/logs目录下,实时查看是否有报错：
@@ -611,7 +611,7 @@ Fateboard是一项Web服务。如果成功启动了fateboard服务，则可以�
 
 ```bash
 cd /data/projects/fate/common/mysql/mysql-*
-sh ./service.sh start|stop|status|restart
+bash ./service.sh start|stop|status|restart
 ```
 
 #### 7.1.2. Eggroll服务管理
@@ -624,13 +624,13 @@ cd /data/projects/fate/eggroll
 启动/关闭/查看/重启所有：
 
 ```bash
-sh ./bin/eggroll.sh all start/stop/status/restart
+bash ./bin/eggroll.sh all start/stop/status/restart
 ```
 
 启动/关闭/查看/重启单个模块(可选：clustermanager，nodemanager，rollsite)：
 
 ```bash
-sh ./bin/eggroll.sh clustermanager start/stop/status/restart
+bash ./bin/eggroll.sh clustermanager start/stop/status/restart
 ```
 
 #### 7.1.3. Fate服务管理
@@ -640,7 +640,7 @@ sh ./bin/eggroll.sh clustermanager start/stop/status/restart
 ```bash
 source /data/projects/fate/bin/init_env.sh
 cd /data/projects/fate/fateflow/bin
-sh service.sh start|stop|status|restart
+bash service.sh start|stop|status|restart
 ```
 
 如果逐个模块启动，需要先启动eggroll再启动fateflow，fateflow依赖eggroll的启动。
@@ -649,7 +649,7 @@ sh service.sh start|stop|status|restart
 
 ```bash
 cd /data/projects/fate/fateboard
-sh service.sh start|stop|status|restart
+bash service.sh start|stop|status|restart
 ```
 
 ### 7.2. 查看进程和端口
@@ -779,4 +779,3 @@ find /data/projects/fate/eggroll/data/IN_MEMORY/ -maxdepth 1 -mindepth 1 -mtime 
 ```bash
 find /data/projects/fate/eggroll/data/LMDB/ -maxdepth 1 -mindepth 1 -mtime +N -type d -name "output_data_*" | xargs rm -rf
 ```
-

--- a/deploy/cluster-deploy/doc/fate_on_eggroll/fate-exchange_deployment_guide.md
+++ b/deploy/cluster-deploy/doc/fate_on_eggroll/fate-exchange_deployment_guide.md
@@ -282,7 +282,7 @@ Modify the content in /data/projects/fate/eggroll/conf/route\_table.json. The de
 #Start the Eggroll service
 source /data/projects/fate/init_env.sh
 cd /data/projects/fate/eggroll
-sh ./bin/eggroll.sh rollsite start
+bash ./bin/eggroll.sh rollsite start
 ```
 
 ## 5.6 Verification and Troubleshooting
@@ -314,7 +314,7 @@ cd /data/projects/fate/eggroll
 Start/Shutdown/View/Restart rollsite:
 
 ```
-sh ./bin/eggroll.sh rollsite start/stop/status/restart
+bash ./bin/eggroll.sh rollsite start/stop/status/restart
 ```
 
 ## 6.2 View Processes and Ports
@@ -341,4 +341,3 @@ netstat -tlnp | grep 9370
 | Service| Log Path
 |----------|----------
 | eggroll| /data/projects/fate/eggroll/logs
-

--- a/deploy/cluster-deploy/doc/fate_on_eggroll/fate-exchange_deployment_guide.zh.md
+++ b/deploy/cluster-deploy/doc/fate_on_eggroll/fate-exchange_deployment_guide.zh.md
@@ -299,7 +299,7 @@ EOF
 #启动eggroll服务
 source /data/projects/fate/init_env.sh
 cd /data/projects/fate/eggroll
-sh ./bin/eggroll.sh rollsite start
+bash ./bin/eggroll.sh rollsite start
 ```
 
 ## 5.6 验证和问题定位
@@ -333,7 +333,7 @@ cd /data/projects/fate/eggroll
 启动/关闭/查看/重启rollsite：
 
 ```
-sh ./bin/eggroll.sh rollsite start/stop/status/restart
+bash ./bin/eggroll.sh rollsite start/stop/status/restart
 ```
 
 ## 6.2 查看进程和端口

--- a/deploy/cluster-deploy/doc/fate_on_spark/common/hadoop_spark_deployment_guide.md
+++ b/deploy/cluster-deploy/doc/fate_on_spark/common/hadoop_spark_deployment_guide.md
@@ -157,7 +157,7 @@ ssh app@192.168.0.3
 2. wget https://archive.apache.org/dist/hadoop/common/hadoop-3.3.1/hadoop-3.3.1.tar.gz
 3. wget https://downloads.lightbend.com/scala/2.12.10/scala-2.12.10.tgz
 4. wget https://archive.apache.org/dist/spark/spark-3.1.2/spark-3.1.2-bin-hadoop3.2.tgz
-5. wget https://archive.apache.org/dist/zookeeper/zookeeper-3.6.3/apache-zookeeper-3.6.3-bin.tar.gz 
+5. wget https://archive.apache.org/dist/zookeeper/zookeeper-3.6.3/apache-zookeeper-3.6.3-bin.tar.gz
 
 **Extract**
 
@@ -647,7 +647,7 @@ export PYSPARK_DRIVER_PYTHON=/data/projects/fate/common/python/venv/bin/python
 **\#Start**
 
 ```bash
-sh /data/projects/common/spark/sbin/start-all.sh
+bash /data/projects/common/spark/sbin/start-all.sh
 ```
 
 **\#Check**

--- a/deploy/cluster-deploy/doc/fate_on_spark/common/hadoop_spark_deployment_guide.zh.md
+++ b/deploy/cluster-deploy/doc/fate_on_spark/common/hadoop_spark_deployment_guide.zh.md
@@ -158,7 +158,7 @@ ssh app@192.168.0.3
 2. wget https://archive.apache.org/dist/hadoop/common/hadoop-3.3.1/hadoop-3.3.1.tar.gz
 3. wget https://downloads.lightbend.com/scala/2.12.10/scala-2.12.10.tgz
 4. wget https://archive.apache.org/dist/spark/spark-3.1.2/spark-3.1.2-bin-hadoop3.2.tgz
-5. wget https://archive.apache.org/dist/zookeeper/zookeeper-3.6.3/apache-zookeeper-3.6.3-bin.tar.gz 
+5. wget https://archive.apache.org/dist/zookeeper/zookeeper-3.6.3/apache-zookeeper-3.6.3-bin.tar.gz
 
 **解压**
 
@@ -653,7 +653,7 @@ export PYSPARK_DRIVER_PYTHON=/data/projects/fate/common/python/venv/bin/python
 **\#启动**
 
 ```bash
-sh /data/projects/common/spark/spark/sbin/start-all.sh
+bash /data/projects/common/spark/spark/sbin/start-all.sh
 ```
 
 **\#验证**
@@ -665,4 +665,3 @@ hdfs dfs -mkdir -p /tmp/spark/event
 hdfs dfs -put *jar /tmp/spark/jars
 /data/projects/common/spark/bin/spark-shell --master yarn --deploy-mode client 
 ```
-

--- a/deploy/cluster-deploy/doc/fate_on_spark/fate_on_spark_deployment_guide.md
+++ b/deploy/cluster-deploy/doc/fate_on_spark/fate_on_spark_deployment_guide.md
@@ -297,7 +297,7 @@ mkdir -p /data/projects/fate/common/python
 cd /data/projects/install
 tar xvf python-env-*.tar.gz
 cd python-env
-sh miniconda3-4.5.4-Linux-x86_64.sh -b -p /data/projects/fate/common/miniconda3
+bash miniconda3-4.5.4-Linux-x86_64.sh -b -p /data/projects/fate/common/miniconda3
 
 #Create a virtualized environment
 /data/projects/fate/common/miniconda3/bin/python3.8 -m venv /data/projects/fate/common/python/venv
@@ -924,11 +924,11 @@ execute under the target server (192.168.0.1 192.168.0.2) app user
 ## Start FATE service, FATE-Flow depends on MySQL to start
 Source code /data/projects/fate/bin/init_env.sh
 cd /data/projects/fate/fateflow/bin
-sh service.sh start
+bash service.sh start
 
 #Start the fateboard service
 cd /data/projects/fate/fateboard
-sh service.sh start
+bash service.sh start
 
 #Start the nginx service
 /data/projects/fate/proxy/nginx/sbin/nginx -c /data/projects/fate/proxy/nginx/conf/nginx.conf
@@ -1081,7 +1081,7 @@ execute under the target server (192.168.0.1 192.168.0.2) app user
 ```bash
 source /data/projects/fate/init_env.sh
 cd /data/projects/fate/fateflow/bin
-sh service.sh start|stop|status|restart
+bash service.sh start|stop|status|restart
 ```
 
 If you start module by module, you need to start eggroll first and then fateflow. fateflow depends on eggroll to start.
@@ -1090,7 +1090,7 @@ If you start module by module, you need to start eggroll first and then fateflow
 
 ```bash
 cd /data/projects/fate/fateboard
-sh service.sh start|stop|status|restart
+bash service.sh start|stop|status|restart
 ```
 
 3) Start/shutdown/restart the NginX service
@@ -1107,7 +1107,7 @@ Start/shutdown/view/restart MySQL services
 
 ```bash
 cd /data/projects/fate/common/mysql/mysql-8.0.13
-sh ./service.sh start|stop|status|restart
+bash ./service.sh start|stop|status|restart
 ```
 
 ### 11.2 Viewing processes and ports

--- a/deploy/cluster-deploy/doc/fate_on_spark/fate_on_spark_deployment_guide.zh.md
+++ b/deploy/cluster-deploy/doc/fate_on_spark/fate_on_spark_deployment_guide.zh.md
@@ -290,7 +290,7 @@ mkdir -p /data/projects/fate/common/python/venv
 
 #安装miniconda3
 cd /data/projects/install
-sh Miniconda3-py38_4.12.0-Linux-x86_64.sh -b -p /data/projects/fate/common/miniconda3
+bash Miniconda3-py38_4.12.0-Linux-x86_64.sh -b -p /data/projects/fate/common/miniconda3
 #创建虚拟化环境
 /data/projects/fate/common/miniconda3/bin/python3.8 -m venv /data/projects/fate/common/python/venv
 
@@ -918,10 +918,10 @@ EOF
 ```
 #启动FATE服务，FATE-Flow依赖MySQL的启动
 cd /data/projects/fate/fateflow/bin
-sh service.sh start
+bash service.sh start
 #启动fateboard服务
 cd /data/projects/fate/fateboard
-sh service.sh start
+bash service.sh start
 #启动nginx服务
 /data/projects/fate/proxy/nginx/sbin/nginx -c /data/projects/fate/proxy/nginx/conf/nginx.conf
 ```
@@ -1073,7 +1073,7 @@ FATEBoard是一项Web服务。如果成功启动了FATEBoard服务，则可以�
 ```bash
 source /data/projects/fate/init_env.sh
 cd /data/projects/fate/fateflow/bin
-sh service.sh start|stop|status|restart
+bash service.sh start|stop|status|restart
 ```
 
 如果逐个模块启动，需要先启动eggroll再启动fateflow，fateflow依赖eggroll的启动。
@@ -1082,7 +1082,7 @@ sh service.sh start|stop|status|restart
 
 ```bash
 cd /data/projects/fate/fateboard
-sh service.sh start|stop|status|restart
+bash service.sh start|stop|status|restart
 ```
 
 3) 启动/关闭/重启NginX服务
@@ -1099,7 +1099,7 @@ cd /data/projects/fate/proxy
 
 ```bash
 cd /data/projects/fate/common/mysql/mysql-8.0.13
-sh ./service.sh start|stop|status|restart
+bash ./service.sh start|stop|status|restart
 ```
 
 ### 11.2 查看进程和端口
@@ -1136,5 +1136,3 @@ netstat -tlnp | grep 9390
 | fateboard          | /data/projects/fate/fateboard/logs                 |
 | nginx | /data/projects/fate/proxy/nginx/logs                 |
 | mysql              | /data/projects/fate/common/mysql/mysql-*/logs |
-
-

--- a/deploy/cluster-deploy/upgrade/1_4_0-1_5_1/fate_upgrade_zh.md
+++ b/deploy/cluster-deploy/upgrade/1_4_0-1_5_1/fate_upgrade_zh.md
@@ -46,10 +46,10 @@ SUPERVISOR_ROOT=/data/projects/common/supervisord
 cd ~/fate_1_4_0-1_5_1/
 
 # 带参数执行如下命令，其中组件名请从：fatepython、fateboard、mysql、all中选择
-sh upgrade.sh <module>
+bash upgrade.sh <module>
 
 # 例如，如果只需要更新fatepython，请执行如下命令：
-sh upgrade.sh fatepython
+bash upgrade.sh fatepython
 ```
 
 如果提示ERROR，... aborting字样，则为参数检查不通过，请根据提示对脚本参数进行二次确认及修改；
@@ -79,7 +79,7 @@ sh upgrade.sh fatepython
 cd /data/projects/fate/python/fate_flow/
 
 # 停止服务
-sh service.sh stop
+bash service.sh stop
 ```
 
 ##### ansible部署方式的停止服务方法
@@ -88,7 +88,7 @@ sh service.sh stop
 cd /data/projects/common/supervisord/
 
 # 停止服务
-sh service.sh stop fate-fateflow
+bash service.sh stop fate-fateflow
 ```
 
 
@@ -141,7 +141,7 @@ alter table t_job_backup150 rename to t_job;
 cd /data/projects/fate/python/fate_flow/
 
 # 启动服务
-sh service.sh start
+bash service.sh start
 ```
 
 ##### ansible部署方式的停止服务方法
@@ -151,7 +151,7 @@ sh service.sh start
 cd /data/projects/common/supervisord/
 
 # 启动服务
-sh service.sh start fate-fateflow
+bash service.sh start fate-fateflow
 ```
 
 
@@ -165,7 +165,7 @@ sh service.sh start fate-fateflow
 cd /data/projects/fate/fateboard/
 
 # 停止服务
-sh service.sh stop
+bash service.sh stop
 ```
 
 ##### ansible部署方式的停止服务方法
@@ -175,7 +175,7 @@ sh service.sh stop
 cd /data/projects/common/supervisord/
 
 # 停止服务
-sh service.sh stop fate-fateboard
+bash service.sh stop fate-fateboard
 ```
 
 
@@ -206,7 +206,7 @@ mv fateboard_150bak_202101011200/ fateboard/
 cd /data/projects/fate/fateboard/
 
 # 停止服务
-sh service.sh start
+bash service.sh start
 ```
 
 ##### ansible部署方式的停止服务方法
@@ -216,7 +216,7 @@ sh service.sh start
 cd /data/projects/common/supervisord/
 
 # 停止服务
-sh service.sh start fate-fateboard
+bash service.sh start fate-fateboard
 ```
 
 
@@ -252,7 +252,7 @@ sh service.sh start fate-fateboard
 cd /data/projects/fate/python/fate_flow/
 
 # 停止服务
-sh service.sh stop
+bash service.sh stop
 ```
 
 ##### ansible部署方式的停止服务方法
@@ -262,7 +262,7 @@ sh service.sh stop
 cd /data/projects/common/supervisord/
 
 # 停止服务
-sh service.sh stop fate-fateflow
+bash service.sh stop fate-fateflow
 ```
 
 
@@ -323,7 +323,7 @@ DROP database fate_flow_backup144;
 cd /data/projects/fate/python/fate_flow/
 
 # 启动服务
-sh service.sh start
+bash service.sh start
 ```
 
 ##### ansible部署方式的停止服务方法
@@ -333,7 +333,7 @@ sh service.sh start
 cd /data/projects/common/supervisord/
 
 # 启动服务
-sh service.sh start fate-fateflow
+bash service.sh start fate-fateflow
 ```
 
 
@@ -347,7 +347,7 @@ sh service.sh start fate-fateflow
 cd /data/projects/fate/fateboard/
 
 # 停止服务
-sh service.sh stop
+bash service.sh stop
 ```
 
 ##### ansible部署方式的停止服务方法
@@ -357,7 +357,7 @@ sh service.sh stop
 cd /data/projects/common/supervisord/
 
 # 停止服务
-sh service.sh stop fate-fateboard
+bash service.sh stop fate-fateboard
 ```
 
 
@@ -388,7 +388,7 @@ mv fateboard_150bak_202101011200/ fateboard/
 cd /data/projects/fate/fateboard/
 
 # 停止服务
-sh service.sh start
+bash service.sh start
 ```
 
 ##### ansible部署方式的停止服务方法
@@ -398,7 +398,7 @@ sh service.sh start
 cd /data/projects/common/supervisord/
 
 # 停止服务
-sh service.sh start fate-fateboard
+bash service.sh start fate-fateboard
 ```
 
 
@@ -438,7 +438,7 @@ sh service.sh start fate-fateboard
 cd /data/projects/fate/python/fate_flow/
 
 # 停止服务
-sh service.sh stop
+bash service.sh stop
 ```
 
 #### ansible部署方式的停止服务方法
@@ -448,7 +448,7 @@ sh service.sh stop
 cd /data/projects/common/supervisord/
 
 # 停止服务
-sh service.sh stop fate-fateflow
+bash service.sh stop fate-fateflow
 ```
 
 
@@ -524,7 +524,7 @@ mv fateboard_140bak_202101011200/ fateboard/
 cd /data/projects/fate/fateboard/
 
 # 停止服务
-sh service.sh start
+bash service.sh start
 ```
 
 ##### ansible部署方式的停止服务方法
@@ -534,7 +534,7 @@ sh service.sh start
 cd /data/projects/common/supervisord/
 
 # 停止服务
-sh service.sh start fate-fateboard
+bash service.sh start fate-fateboard
 ```
 
 
@@ -548,7 +548,7 @@ sh service.sh start fate-fateboard
 cd /data/projects/fate/python/fate_flow/
 
 # 启动服务
-sh service.sh start
+bash service.sh start
 ```
 
 #### ansible部署方式的停止服务方法
@@ -558,7 +558,7 @@ sh service.sh start
 cd /data/projects/common/supervisord/
 
 # 启动服务
-sh service.sh start fate-fateflow
+bash service.sh start fate-fateflow
 ```
 
 

--- a/deploy/cluster-deploy/upgrade/1_4_3-1_5_1/fate_upgrade_zh.md
+++ b/deploy/cluster-deploy/upgrade/1_4_3-1_5_1/fate_upgrade_zh.md
@@ -45,10 +45,10 @@ SUPERVISOR_ROOT=/data/projects/common/supervisord
 cd ~/fate_1_4_3-1_5_1/
 
 # 带参数执行如下命令，其中组件名请从：fatepython、fateboard、mysql、all中选择
-sh upgrade.sh <module>
+bash upgrade.sh <module>
 
 # 例如，如果只需要更新fatepython，请执行如下命令：
-sh upgrade.sh fatepython
+bash upgrade.sh fatepython
 ```
 
 如果提示ERROR，... aborting字样，则为参数检查不通过，请根据提示对脚本参数进行二次确认及修改；
@@ -78,7 +78,7 @@ sh upgrade.sh fatepython
 cd /data/projects/fate/python/fate_flow/
 
 # 停止服务
-sh service.sh stop
+bash service.sh stop
 ```
 
 ##### ansible部署方式的停止服务方法
@@ -87,7 +87,7 @@ sh service.sh stop
 cd /data/projects/common/supervisord/
 
 # 停止服务
-sh service.sh stop fate-fateflow
+bash service.sh stop fate-fateflow
 ```
 
 
@@ -140,7 +140,7 @@ alter table t_job_backup150 rename to t_job;
 cd /data/projects/fate/python/fate_flow/
 
 # 启动服务
-sh service.sh start
+bash service.sh start
 ```
 
 ##### ansible部署方式的停止服务方法
@@ -150,7 +150,7 @@ sh service.sh start
 cd /data/projects/common/supervisord/
 
 # 启动服务
-sh service.sh start fate-fateflow
+bash service.sh start fate-fateflow
 ```
 
 
@@ -164,7 +164,7 @@ sh service.sh start fate-fateflow
 cd /data/projects/fate/fateboard/
 
 # 停止服务
-sh service.sh stop
+bash service.sh stop
 ```
 
 ##### ansible部署方式的停止服务方法
@@ -174,7 +174,7 @@ sh service.sh stop
 cd /data/projects/common/supervisord/
 
 # 停止服务
-sh service.sh stop fate-fateboard
+bash service.sh stop fate-fateboard
 ```
 
 
@@ -205,7 +205,7 @@ mv fateboard_150bak_202101011200/ fateboard/
 cd /data/projects/fate/fateboard/
 
 # 停止服务
-sh service.sh start
+bash service.sh start
 ```
 
 ##### ansible部署方式的停止服务方法
@@ -215,7 +215,7 @@ sh service.sh start
 cd /data/projects/common/supervisord/
 
 # 停止服务
-sh service.sh start fate-fateboard
+bash service.sh start fate-fateboard
 ```
 
 
@@ -251,7 +251,7 @@ sh service.sh start fate-fateboard
 cd /data/projects/fate/python/fate_flow/
 
 # 停止服务
-sh service.sh stop
+bash service.sh stop
 ```
 
 ##### ansible部署方式的停止服务方法
@@ -261,7 +261,7 @@ sh service.sh stop
 cd /data/projects/common/supervisord/
 
 # 停止服务
-sh service.sh stop fate-fateflow
+bash service.sh stop fate-fateflow
 ```
 
 
@@ -322,7 +322,7 @@ DROP database fate_flow_backup144;
 cd /data/projects/fate/python/fate_flow/
 
 # 启动服务
-sh service.sh start
+bash service.sh start
 ```
 
 ##### ansible部署方式的停止服务方法
@@ -332,7 +332,7 @@ sh service.sh start
 cd /data/projects/common/supervisord/
 
 # 启动服务
-sh service.sh start fate-fateflow
+bash service.sh start fate-fateflow
 ```
 
 
@@ -346,7 +346,7 @@ sh service.sh start fate-fateflow
 cd /data/projects/fate/fateboard/
 
 # 停止服务
-sh service.sh stop
+bash service.sh stop
 ```
 
 ##### ansible部署方式的停止服务方法
@@ -356,7 +356,7 @@ sh service.sh stop
 cd /data/projects/common/supervisord/
 
 # 停止服务
-sh service.sh stop fate-fateboard
+bash service.sh stop fate-fateboard
 ```
 
 
@@ -387,7 +387,7 @@ mv fateboard_150bak_202101011200/ fateboard/
 cd /data/projects/fate/fateboard/
 
 # 停止服务
-sh service.sh start
+bash service.sh start
 ```
 
 ##### ansible部署方式的停止服务方法
@@ -397,7 +397,7 @@ sh service.sh start
 cd /data/projects/common/supervisord/
 
 # 停止服务
-sh service.sh start fate-fateboard
+bash service.sh start fate-fateboard
 ```
 
 
@@ -433,7 +433,7 @@ sh service.sh start fate-fateboard
 cd /data/projects/fate/python/fate_flow/
 
 # 停止服务
-sh service.sh stop
+bash service.sh stop
 ```
 
 ##### ansible部署方式的停止服务方法
@@ -443,7 +443,7 @@ sh service.sh stop
 cd /data/projects/common/supervisord/
 
 # 停止服务
-sh service.sh stop fate-fateflow
+bash service.sh stop fate-fateflow
 ```
 
 
@@ -474,7 +474,7 @@ mv python_143bak_202101011200/ python/
 cd /data/projects/fate/python/fate_flow/
 
 # 启动服务
-sh service.sh start
+bash service.sh start
 ```
 
 ##### ansible部署方式的停止服务方法
@@ -484,7 +484,7 @@ sh service.sh start
 cd /data/projects/common/supervisord/
 
 # 启动服务
-sh service.sh start fate-fateflow
+bash service.sh start fate-fateflow
 ```
 
 

--- a/deploy/cluster-deploy/upgrade/1_4_4-1_5_1/fate_upgrade_zh.md
+++ b/deploy/cluster-deploy/upgrade/1_4_4-1_5_1/fate_upgrade_zh.md
@@ -45,10 +45,10 @@ SUPERVISOR_ROOT=/data/projects/common/supervisord
 cd ~/fate_1_4_4-1_5_1/
 
 # 带参数执行如下命令，其中组件名请从：fatepython、fateboard、mysql、all中选择
-sh upgrade.sh <module>
+bash upgrade.sh <module>
 
 # 例如，如果只需要更新fatepython，请执行如下命令：
-sh upgrade.sh fatepython
+bash upgrade.sh fatepython
 ```
 
 如果提示ERROR，... aborting字样，则为参数检查不通过，请根据提示对脚本参数进行二次确认及修改；
@@ -76,7 +76,7 @@ sh upgrade.sh fatepython
 cd /data/projects/fate/python/fate_flow/
 
 # 停止服务
-sh service.sh stop
+bash service.sh stop
 ```
 
 ##### ansible部署方式的停止服务方法
@@ -85,7 +85,7 @@ sh service.sh stop
 cd /data/projects/common/supervisord/
 
 # 停止服务
-sh service.sh stop fate-fateflow
+bash service.sh stop fate-fateflow
 ```
 
 
@@ -138,7 +138,7 @@ alter table t_job_backup150 rename to t_job;
 cd /data/projects/fate/python/fate_flow/
 
 # 启动服务
-sh service.sh start
+bash service.sh start
 ```
 
 ##### ansible部署方式的停止服务方法
@@ -148,7 +148,7 @@ sh service.sh start
 cd /data/projects/common/supervisord/
 
 # 启动服务
-sh service.sh start fate-fateflow
+bash service.sh start fate-fateflow
 ```
 
 
@@ -162,7 +162,7 @@ sh service.sh start fate-fateflow
 cd /data/projects/fate/fateboard/
 
 # 停止服务
-sh service.sh stop
+bash service.sh stop
 ```
 
 ##### ansible部署方式的停止服务方法
@@ -172,7 +172,7 @@ sh service.sh stop
 cd /data/projects/common/supervisord/
 
 # 停止服务
-sh service.sh stop fate-fateboard
+bash service.sh stop fate-fateboard
 ```
 
 
@@ -203,7 +203,7 @@ mv fateboard_150bak_202101011200/ fateboard/
 cd /data/projects/fate/fateboard/
 
 # 停止服务
-sh service.sh start
+bash service.sh start
 ```
 
 ##### ansible部署方式的停止服务方法
@@ -213,7 +213,7 @@ sh service.sh start
 cd /data/projects/common/supervisord/
 
 # 停止服务
-sh service.sh start fate-fateboard
+bash service.sh start fate-fateboard
 ```
 
 
@@ -249,7 +249,7 @@ sh service.sh start fate-fateboard
 cd /data/projects/fate/python/fate_flow/
 
 # 停止服务
-sh service.sh stop
+bash service.sh stop
 ```
 
 ##### ansible部署方式的停止服务方法
@@ -259,7 +259,7 @@ sh service.sh stop
 cd /data/projects/common/supervisord/
 
 # 停止服务
-sh service.sh stop fate-fateflow
+bash service.sh stop fate-fateflow
 ```
 
 
@@ -320,7 +320,7 @@ DROP database fate_flow_backup144;
 cd /data/projects/fate/python/fate_flow/
 
 # 启动服务
-sh service.sh start
+bash service.sh start
 ```
 
 ##### ansible部署方式的停止服务方法
@@ -330,7 +330,7 @@ sh service.sh start
 cd /data/projects/common/supervisord/
 
 # 启动服务
-sh service.sh start fate-fateflow
+bash service.sh start fate-fateflow
 ```
 
 
@@ -344,7 +344,7 @@ sh service.sh start fate-fateflow
 cd /data/projects/fate/fateboard/
 
 # 停止服务
-sh service.sh stop
+bash service.sh stop
 ```
 
 ##### ansible部署方式的停止服务方法
@@ -354,7 +354,7 @@ sh service.sh stop
 cd /data/projects/common/supervisord/
 
 # 停止服务
-sh service.sh stop fate-fateboard
+bash service.sh stop fate-fateboard
 ```
 
 
@@ -385,7 +385,7 @@ mv fateboard_150bak_202101011200/ fateboard/
 cd /data/projects/fate/fateboard/
 
 # 停止服务
-sh service.sh start
+bash service.sh start
 ```
 
 ##### ansible部署方式的停止服务方法
@@ -395,7 +395,7 @@ sh service.sh start
 cd /data/projects/common/supervisord/
 
 # 停止服务
-sh service.sh start fate-fateboard
+bash service.sh start fate-fateboard
 ```
 
 

--- a/deploy/cluster-deploy/upgrade/1_5_0-1_5_1/resource/fate_upgrade_zh.md
+++ b/deploy/cluster-deploy/upgrade/1_5_0-1_5_1/resource/fate_upgrade_zh.md
@@ -48,13 +48,13 @@ SUPERVISOR_ROOT=/data/projects/common/supervisord
 cd ~/upgrade_1_5_0-1_5_1/
 
 # 带参数执行如下命令，其中组件名请从：fatepython、fateflow、mysql、all中选择
-sh upgrade.sh <module>
+bash upgrade.sh <module>
 
 # 例如，如果只需要更新fatepython，请执行如下命令：
-sh upgrade.sh fatepython
+bash upgrade.sh fatepython
 
 # 若所有服务均部署在同一台机器，请使用all，否则不能使用all:
-sh upgrade.sh all
+bash upgrade.sh all
 ```
 
 如果提示ERROR，... aborting字样，则为参数检查不通过，请根据提示对脚本参数进行二次确认及修改；
@@ -66,19 +66,19 @@ sh upgrade.sh all
 ### 3.2 更新mysql(mysql所在机器)
 
 ```bash
-sh upgrade.sh mysql
+bash upgrade.sh mysql
 ```
 
 ### 3.3 更新fatepython(fateflow、nodemanager所在机器)
 
 ```bash
-sh upgrade.sh fatepython
+bash upgrade.sh fatepython
 ```
 
 ### 3.4 更新fateboard(fateboard所在机器)
 
 ```bash
-sh upgrade.sh fateboard
+bash upgrade.sh fateboard
 ```
 
 ## 4. 更新回滚
@@ -94,7 +94,7 @@ sh upgrade.sh fateboard
 cd /data/projects/fate/python/fate_flow/
 
 # 停止服务
-sh service.sh stop
+bash service.sh stop
 ```
 
 ##### ansible部署方式的停止服务方法
@@ -103,7 +103,7 @@ sh service.sh stop
 cd /data/projects/common/supervisord/
 
 # 停止服务
-sh service.sh stop fate-fateflow
+bash service.sh stop fate-fateflow
 ```
 
 
@@ -156,7 +156,7 @@ alter table t_job_backup150 rename to t_job;
 cd /data/projects/fate/python/fate_flow/
 
 # 启动服务
-sh service.sh start
+bash service.sh start
 ```
 
 ##### ansible部署方式的停止服务方法
@@ -166,7 +166,7 @@ sh service.sh start
 cd /data/projects/common/supervisord/
 
 # 启动服务
-sh service.sh start fate-fateflow
+bash service.sh start fate-fateflow
 ```
 
 
@@ -180,7 +180,7 @@ sh service.sh start fate-fateflow
 cd /data/projects/fate/fateboard/
 
 # 停止服务
-sh service.sh stop
+bash service.sh stop
 ```
 
 ##### ansible部署方式的停止服务方法
@@ -190,7 +190,7 @@ sh service.sh stop
 cd /data/projects/common/supervisord/
 
 # 停止服务
-sh service.sh stop fate-fateboard
+bash service.sh stop fate-fateboard
 ```
 
 
@@ -221,7 +221,7 @@ mv fateboard_150bak_202101011200/ fateboard/
 cd /data/projects/fate/fateboard/
 
 # 停止服务
-sh service.sh start
+bash service.sh start
 ```
 
 ##### ansible部署方式的停止服务方法
@@ -231,7 +231,7 @@ sh service.sh start
 cd /data/projects/common/supervisord/
 
 # 停止服务
-sh service.sh start fate-fateboard
+bash service.sh start fate-fateboard
 ```
 
 

--- a/deploy/cluster-deploy/upgrade/1_5_0-1_5_1/resource/upgrade.sh
+++ b/deploy/cluster-deploy/upgrade/1_5_0-1_5_1/resource/upgrade.sh
@@ -90,7 +90,7 @@ function check_mysql_conn() {
   else
     echo "INFO: Done."
   fi
-  
+
   $MYSQL_ROOT/bin/mysql -u$DB_USER -p$DB_PASS -S $MYSQL_SOCKET_PATH -e "select 'x';"
   if [ $? -ne 0 ]; then
     echo "ERROR: Mysql connect failed. Upgrade process aborting.";
@@ -116,10 +116,10 @@ function stop_fateflow() {
   echo "INFO: Stopping fate flow server..."
   case $DEPLOY_METHOD in
     "allinone")
-      sh $FATE_PYTHON_ROOT/fate_flow/service.sh stop
+      bash $FATE_PYTHON_ROOT/fate_flow/service.sh stop
       ;;
     "ansible")
-      sh $SUPERVISOR_ROOT/service.sh stop fate-fateflow
+      bash $SUPERVISOR_ROOT/service.sh stop fate-fateflow
       ;;
   esac
 }
@@ -129,10 +129,10 @@ function start_fateflow() {
   echo "INFO: Starting fate flow server..."
   case $DEPLOY_METHOD in
     "allinone")
-      sh $FATE_PYTHON_ROOT/fate_flow/service.sh start
+      bash $FATE_PYTHON_ROOT/fate_flow/service.sh start
       ;;
     "ansible")
-      sh $SUPERVISOR_ROOT/service.sh start fate-fateflow
+      bash $SUPERVISOR_ROOT/service.sh start fate-fateflow
       ;;
   esac
 }
@@ -142,10 +142,10 @@ function stop_fateboard() {
   echo "INFO: Stopping fateboard..."
   case $DEPLOY_METHOD in
     "allinone")
-      sh $FATEBOARD_ROOT/service.sh stop
+      bash $FATEBOARD_ROOT/service.sh stop
       ;;
     "ansible")
-      sh $SUPERVISOR_ROOT/service.sh stop fate-fateboard
+      bash $SUPERVISOR_ROOT/service.sh stop fate-fateboard
       ;;
   esac
 }
@@ -155,11 +155,11 @@ function start_fateboard() {
   echo "INFO: Starting fateboard..."
   case $DEPLOY_METHOD in
     "allinone")
-      sh $FATEBOARD_ROOT/service.sh start
+      bash $FATEBOARD_ROOT/service.sh start
       ;;
     "ansible")
-      sh $SUPERVISOR_ROOT/service.sh update fate-fateboard
-      sh $SUPERVISOR_ROOT/service.sh start fate-fateboard
+      bash $SUPERVISOR_ROOT/service.sh update fate-fateboard
+      bash $SUPERVISOR_ROOT/service.sh start fate-fateboard
       ;;
   esac
 }

--- a/deploy/cluster-deploy/upgrade/eggroll_2_0_x-2_2_1/upgrade_helper_guide_zh.md
+++ b/deploy/cluster-deploy/upgrade/eggroll_2_0_x-2_2_1/upgrade_helper_guide_zh.md
@@ -50,14 +50,14 @@
 - allinone 部署方式的停止服务方法
 ```
 cd ${EGGROLL_HOME}
-sh bin/eggroll.sh all stop
+bash bin/eggroll.sh all stop
 ```
 - ansible 部署方式的停止服务方法
 ```
 cd /data/projects/common/supervisord
-sh service.sh stop fate-clustermanager
-sh service.sh stop fate-nodemanager
-sh service.sh stop fate-rollsite
+bash service.sh stop fate-clustermanager
+bash service.sh stop fate-nodemanager
+bash service.sh stop fate-rollsite
 ```
 
 - eggroll手动备份
@@ -89,7 +89,7 @@ ${MYSQL_HOME_PATH}/bin/mysqldump -h <mysql-host> -u <username> -p<passwd> -P <po
 
 ## 3. 使用说明
 
-### 3.1 
+### 3.1
 
 #### 3.1.1 升级脚本部署
 
@@ -104,11 +104,11 @@ ${MYSQL_HOME_PATH}/bin/mysqldump -h <mysql-host> -u <username> -p<passwd> -P <po
 
 ```
 ├─eggroll
-      ├─bin 
-      ├─deploy 
-      ├─lib  
-      └─python 
-   
+      ├─bin
+      ├─deploy
+      ├─lib
+      └─python
+
 ```
 
 ##### 3.1.1.1 获取升级脚本
@@ -174,7 +174,7 @@ eggroll.rollsite.adapter.sendbuf.size=100000
 `/data/projects/fate/`目录，执行以下操作
 
 ```
-mkdir -p /data/projects/fate/ 
+mkdir -p /data/projects/fate/
 unzip /data/projects/fate/eggroll-2.0.1.zip
 cp -r /data/projects/fate/eggroll-2.0.1 /data/projects/fate/eggroll
 echo "__version__ = "2.0.1"" > /data/projects/fate/eggroll/python/eggroll/__init__.py
@@ -187,7 +187,7 @@ echo "__version__ = "2.0.1"" > /data/projects/fate/eggroll/python/eggroll/__init
 `/data/projects/fate/`目录，执行以下操作
 
 ```
-mkdir -p /data/projects/fate/ 
+mkdir -p /data/projects/fate/
 unzip /data/projects/fate/eggroll-2.0.2.zip
 cp -r /data/projects/fate/eggroll-2.0.2 /data/projects/fate/eggroll
 echo "__version__ = "2.0.2"" > /data/projects/fate/eggroll/python/eggroll/__init__.py
@@ -200,7 +200,7 @@ echo "__version__ = "2.0.2"" > /data/projects/fate/eggroll/python/eggroll/__init
 `/data/projects/fate/`目录，执行以下操作
 
 ```
-mkdir -p /data/projects/fate/ 
+mkdir -p /data/projects/fate/
 unzip /data/projects/fate/eggroll-2.2.0.zip
 cp -r /data/projects/fate/eggroll-2.2.0 /data/projects/fate/eggroll
 ```
@@ -269,7 +269,7 @@ alter table session_processor modify column session_id VARCHAR(767);
 
 ```
 python ${PKG_BASE_PATH}/eggroll/deploy/upgrade_helper.py --help
-python upgrade_helper.py 
+python upgrade_helper.py
  -c --nm_file <input eggroll upgrade  namenode node ip sets>
  -r --rs_file <input eggroll upgrade only rollsite node ip sets>
  -e --egg_home <eggroll home path>
@@ -340,11 +340,11 @@ less log.info | grep "current machine not install mysql "
 > alter table session_option add store_option_id SERIAL PRIMARY KEY;
 > alter table session_main modify column session_id VARCHAR(767);
 > alter table session_processor modify column session_id VARCHAR(767);
-> 
-> 
+>
+>
 > ```
 >
-> ## 
+> ##
 
 
 - 4.4 版本检查
@@ -431,4 +431,3 @@ vim内搜索：{module}.err &
 cp ${EGGROLL_HOME}/bin/eggroll.sh ${EGGROLL_HOME}/bin/fate-eggroll.sh
 sed -i '26 i source $cwd/../../bin/init_env.sh' ${EGGROLL_HOME}/bin/fate-eggroll.sh
 ```
-

--- a/python/federatedml/test/README.md
+++ b/python/federatedml/test/README.md
@@ -4,6 +4,6 @@ A script to run all the unit tests has been provided in ./python/federatedml/tes
 
 Once FATE is installed, tests can be run using:
 
-$ sh ./python/federatedml/test/run_test.sh
+bash ./python/federatedml/test/run_test.sh
 
 All the unit tests should pass if FATE is installed properly.


### PR DESCRIPTION
On Centos, `sh` is linked to `bash`. On Ubuntu, `sh` is linked to `dash`.

`dash` is not compatible with `bash`. See #4494.
