### PR TITLE
修复特征分箱组件在预测任务中行为不一致的问题

### DIFF
--- a/python/federatedml/feature/hetero_feature_binning/base_feature_binning.py
+++ b/python/federatedml/feature/hetero_feature_binning/base_feature_binning.py
@@ -373,6 +373,13 @@ class BaseFeatureBinning(ModelBase):
         """
 
         self._stage = "transform"
+        # add missing parameters while loading trained model
+        self.model_param.bin_names = list(model_meta.cols)
+        if model_meta.transform_param:
+            self.model_param.transform_param.transform_cols = list(model_meta.transform_param.transform_cols)
+            self.model_param.transform_param.transform_type = model_meta.transform_param.transform_type
+        if model_meta.skip_static:
+            self.model_param.skip_static = model_meta.skip_static
 
     def export_model(self):
         if self.model_output is not None:

--- a/python/federatedml/feature/hetero_feature_binning/base_feature_binning.py
+++ b/python/federatedml/feature/hetero_feature_binning/base_feature_binning.py
@@ -375,6 +375,9 @@ class BaseFeatureBinning(ModelBase):
         self._stage = "transform"
         # add missing parameters while loading trained model
         self.model_param.bin_names = list(model_meta.cols)
+        # force configure bin_indexes to empty list because model_meta.cols is all bin col name,
+        # defult bin_indexs = -1, so it will process all column during transform stage.
+        self.model_param.bin_indexes = []
         if model_meta.transform_param:
             self.model_param.transform_param.transform_cols = list(model_meta.transform_param.transform_cols)
             self.model_param.transform_param.transform_type = model_meta.transform_param.transform_type


### PR DESCRIPTION
在训练过程中，指定参与分箱的列(bin_names)， 并且设置不同的转换类型（如箱号、woe）等参数（transform_param.transform_cols 和transform_param.transform_type)， 训练过程结束后，数据能够按预期的进行数据转换或者不处理，但是在离线预测任务中，由于缺失对应的参数，导致预测结果的数据转换后与训练过程的转换逻辑不一致

Signed-off-by: jsuper <ling.java@gmail.com>

如何重现：
1、在纵向特征分箱任务中，指定部分列参与计算，并且设置不同的变量转换方式。
2、训练完成后，使用该训练任务的模型进行离线预测，组件执行报错或者数据未按预期进行转换。

Changes:

1. 加载模型时，加载对应参数

