### PR TITLE
fix exactly_sample for spark (#4721)

### DIFF
--- a/python/fate_arch/computing/spark/_table.py
+++ b/python/fate_arch/computing/spark/_table.py
@@ -314,9 +314,12 @@ def _exactly_sample(rdd, num: int, seed: int):
     # random the size of each split
     sampled_size = {}
     for split, size in split_size.items():
-        sampled_size[split] = hypergeom.rvs(M=total, n=size, N=num)
-        total = total - size
-        num = num - sampled_size[split]
+        if size <= 0:
+            sampled_size[split] = 0
+        else:
+            sampled_size[split] = hypergeom.rvs(M=total, n=size, N=num)
+            total = total - size
+            num = num - sampled_size[split]
 
     return rdd.mapPartitionsWithIndex(
         _ReservoirSample(split_sample_size=sampled_size, seed=seed).func,


### PR DESCRIPTION
implemented exactly_sample function for spark will failed when there are partitions empty(ie: partition sums close or greater than num data)

this pull request fix #4721 


