### PR TITLE
add import os in pipeline_tutorial_match_id.ipynb

### DIFF
--- a/doc/tutorial/pipeline/pipeline_tutorial_match_id.ipynb
+++ b/doc/tutorial/pipeline/pipeline_tutorial_match_id.ipynb
@@ -178,6 +178,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
     "data_base = \"/workspace/FATE/\"\n",
     "pipeline_upload.add_upload_data(file=os.path.join(data_base, \"examples/data/breast_hetero_guest.csv\"),\n",
     "                                table_name=dense_data_guest[\"name\"],             # table name\n",


### PR DESCRIPTION
import os is missing in pipeline_tutorial_match_id.ipynb code block

Signed-off-by: brandonJY@users.noreply.github.com

