### PR TITLE
DataFrame Bug Fix When PSI Result Equals to 0

### DIFF
--- a/python/fate/arch/dataframe/ops/_indexer.py
+++ b/python/fate/arch/dataframe/ops/_indexer.py
@@ -197,6 +197,14 @@ def flatten_data(df: DataFrame, key_type="block_id", with_sample_id=True):
 
 
 def transform_flatten_data_to_df(ctx, flatten_table, data_manager: DataManager, key_type, value_with_sample_id=True):
+    if flatten_table.count() == 0:
+        return DataFrame(
+            ctx=ctx,
+            block_table=flatten_table,
+            partition_order_mappings=dict(),
+            data_manager=data_manager.duplicate()
+        )
+    
     partition_order_mappings = get_partition_order_by_raw_table(flatten_table,
                                                                 data_manager.block_row_size,
                                                                 key_type=key_type)


### PR DESCRIPTION
…is empty

Signed-off-by: mgqa34 mgq3374541@163.com

Changes:

1. dataframe: fix transform_flatten_data_to_dataframe when flatten_data is empty


