### PR TITLE
Update test_linr.py

### DIFF
--- a/examples/pipeline/sshe_linr/test_linr.py
+++ b/examples/pipeline/sshe_linr/test_linr.py
@@ -41,7 +41,7 @@ def main(config="../config.yaml", namespace=""):
                       epochs=2,
                       batch_size=100,
                       init_param={"fit_intercept": True},
-                      train_data=scale_0.outputs["output_data"],
+                      train_data=scale_0.outputs["train_output_data"],
                       reveal_every_epoch=False,
                       early_stop="diff",
                       reveal_loss_freq=1,


### PR DESCRIPTION
Signed-off-by: asdfsx <asdfsx@gmail.com>

normal-linr in sshe_linr_testsuite can not be submitted. 

![image](https://github.com/FederatedAI/FATE/assets/2292716/c1d63036-8530-4b4c-91a1-55c1f56f90b3)

After I print the exception, I got the error

```
Traceback (most recent call last):
  File "/data/projects/fate/venv/lib/python3.8/site-packages/fate_test-2.0.0-py3.8.egg/fate_test/scripts/testsuite_cli.py", line 178, in _run_pipeline_jobs
    mod.main(config=config)
  File "/data/projects/fate/examples/pipeline/sshe_linr/test_linr.py", line 44, in main
    train_data=scale_0.outputs["output_data"],
KeyError: 'output_data'
```

Changes:

1. examples/pipeline/sshe_linr/test_linr.py


