### PR TITLE
Update fate-exchange_deployment_guide.zh.md

### DIFF
--- a/deploy/cluster-deploy/allinone/fate-exchange_deployment_guide.zh.md
+++ b/deploy/cluster-deploy/allinone/fate-exchange_deployment_guide.zh.md
@@ -316,7 +316,7 @@ EOF
 
 **需要连接exchange的各party的osx模块，app用户修改**
 
-修改/data/projects/fate/osx/conf/broker/route_table.json部分，默认路由信息指向部署好的exchange，不需要配置对端fateflow信息，修改后需重启osx：
+修改/data/projects/fate/osx/conf/broker/route_table.json部分，默认路由信息指向部署好的exchange，并配置本方fateflow等信息，不需要配置对端rollsite或者osx信息，修改后需重启osx：
 
 ```
  "default": {
@@ -327,6 +327,35 @@ EOF
                 }
             ]
         }
+```
+比如party9999，即目标服务器（192.168.0.2）配置 /data/projects/fate/osx/conf/broker/route_table.json为：
+
+```
+{
+        "route_table": {
+                "default": {
+                        "default": [
+                                {
+                                        "ip": "192.168.0.1",
+                                        "port": 9370
+                                }
+                        ]
+                },
+                "9999": {
+                        "default": [{
+                                "ip": "rollsite",
+                                "port": 9370
+                        }],
+                        "fateflow": [{
+                                "ip": "fateflow",
+                                "port": 9360
+                        }]
+                }
+        },
+        "permission": {
+                "default_allow": true
+        }
+}
 ```
 
 


### PR DESCRIPTION
修改 fate-exchange_deployment_guide.zh.md，并增加需要连接exchange的各party的osx模块的route_table.json 示例。

Signed-off-by: GreyJeremyJi

Changes:

1、修改route_table,json 配置信息的表述。原表述中“不需要配置对端fateflow信息”，表述不准确，填写对方fateflow是无效的。除了配置本方默认路由信息，也要配置本方fateflow等信息。

2、增加连接exchange的各party的osx模块的route_table.json 示例，避免引起歧义。

以上配置文件，在exchange模式下通过了测试。

Signed-off-by: jiyaozong <1048442010@qq.com>