### PR TITLE
Bump and rename sslcontext-kicktart to ayza

### DIFF
--- a/java/osx/osx-broker/pom.xml
+++ b/java/osx/osx-broker/pom.xml
@@ -165,8 +165,8 @@
         </dependency>
         <dependency>
             <groupId>io.github.hakky54</groupId>
-            <artifactId>sslcontext-kickstart-for-netty</artifactId>
-            <version>8.1.6</version>
+            <artifactId>ayza-for-netty</artifactId>
+            <version>10.0.0</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
The library has been renamed from sslcontext-kickstart to [ayza](https://github.com/Hakky54/ayza). The latest version is 10.0.0

Sorry for the inconvenience